### PR TITLE
Exit if GOPATH is not set

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -91,6 +91,8 @@ done
 
 shift $(($OPTIND - 1))
 
+[ -z "$GOPATH" ] && die "GOPATH not set"
+
 distro="$1"
 
 [ -n "${distro}" ] || usage 1


### PR DESCRIPTION
If for some reason the GOPATH variable is not set
in the shell the script should exit instead of continuing the execution. 

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>