### PR TITLE
docs: Fix image builder instructions.

### DIFF
--- a/image-builder/README.md
+++ b/image-builder/README.md
@@ -11,7 +11,7 @@ This uses a rootfs directory created by the `rootfs-builder/rootfs.sh` script.
 To create a guest OS image run:
 
 ```
-$ ./image_builder.sh path/to/rootfs
+$ sudo ./image_builder.sh path/to/rootfs
 ```
 
 Where `path/to/rootfs` is the directory populated by `rootfs.sh`.


### PR DESCRIPTION
The `image_builder.sh` script must be run as `root`.

Fixes #36.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>