### PR TITLE
Add missing packages for centos Dockerfile

### DIFF
--- a/rootfs-builder/centos/Dockerfile
+++ b/rootfs-builder/centos/Dockerfile
@@ -1,1 +1,2 @@
 FROM centos:7
+RUN yum install -y make git gcc


### PR DESCRIPTION
'make git gcc' are needed to build agent

Fixes issue: 43