### PR TITLE
Allow to use agent as init process and create initrd image based on rootfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ dist: trusty
 
 language: bash
 
+env:
+  - AGENT_INIT=no
+  - AGENT_INIT=yes
+
 services:
   - docker
 
 before_script:
   - ".ci/setup.sh"
 
-script: 
+script:
 - "travis_wait .ci/run.sh"

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,8 @@ rootfs:
 
 image: rootfs
 	@echo Creating image based on "$(DISTRO_ROOTFS)"
-	AGENT_BIN="$(AGENT_BIN)" "$(MK_DIR)/image-builder/image_builder.sh" -s "$(IMG_SIZE)" "$(DISTRO_ROOTFS)"
+	"$(MK_DIR)/image-builder/image_builder.sh" -s "$(IMG_SIZE)" "$(DISTRO_ROOTFS)"
+
+initrd: rootfs
+	@echo Creating initrd image based on "$(DISTRO_ROOTFS)"
+	"$(MK_DIR)/initrd-builder/initrd_builder.sh" "$(DISTRO_ROOTFS)"

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,12 @@ MK_DIR :=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 DISTRO ?= centos
 DISTRO_ROOTFS := "$(PWD)/$(DISTRO)_rootfs"
 IMG_SIZE=500
+AGENT_INIT ?= no
 
-image:
+rootfs:
 	@echo Creating rootfs based on "$(DISTRO)"
 	"$(MK_DIR)/rootfs-builder/rootfs.sh" -r "$(DISTRO_ROOTFS)" "$(DISTRO)"
+
+image: rootfs
 	@echo Creating image based on "$(DISTRO_ROOTFS)"
 	AGENT_BIN="$(AGENT_BIN)" "$(MK_DIR)/image-builder/image_builder.sh" -s "$(IMG_SIZE)" "$(DISTRO_ROOTFS)"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ This section describes the terms used for all documentation in this repository.
 
   See [the image builder documentation](image-builder/README.md).
 
+- initrd (or "initramfs")
+
+  A compressed cpio archive loaded into memory and used as part of the Linux
+  startup process. During startup, the kernel unpacks it into a special
+  instance of a tmpfs that becomes the initial root file system.
+
+  See [the initrd builder documentation](initrd-builder/README.md).
+
 - "Base OS"
 
   A particular version of a Linux distribution used to create a Guest OS from.

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -96,6 +96,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 		--runtime runc  \
 		--privileged \
 		--env IMG_SIZE="${IMG_SIZE}" \
+		--env AGENT_INIT=${AGENT_INIT} \
 		-v /dev:/dev \
 		-v "${script_dir}":"/osbuilder" \
 		-v "${ROOTFS}":"/rootfs" \

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -16,6 +16,7 @@ fi
 SCRIPT_NAME="${0##*/}"
 IMAGE="${IMAGE:-kata-containers.img}"
 AGENT_BIN=${AGENT_BIN:-kata-agent}
+AGENT_INIT=${AGENT_INIT:-no}
 
 die()
 {
@@ -50,7 +51,8 @@ Options:
 	-s Image size in MB (default $IMG_SIZE) ENV: IMG_SIZE
 
 Extra environment variables:
-	AGENT_BIN:  use it to change the expected agent binary name"
+	AGENT_BIN:  use it to change the expected agent binary name
+	AGENT_INIT: use kata agent as init process
 	USE_DOCKER: If set will build image in a Docker Container (requries docker)
 	            DEFAULT: not set
 EOT
@@ -107,7 +109,7 @@ fi
 init="${ROOTFS}/sbin/init"
 [ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
 OK "init is installed"
-[ -x "${ROOTFS}/bin/${AGENT_BIN}" ] || \
+[ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/bin/${AGENT_BIN}" ] || \
 	die "/bin/${AGENT_BIN} is not installed in ${ROOTFS}
 	use AGENT_BIN env variable to change the expected agent binary name"
 OK "Agent installed"

--- a/initrd-builder/README.md
+++ b/initrd-builder/README.md
@@ -1,0 +1,25 @@
+* [Creating a guest OS initrd image](#creating-a-guest-os-initrd-image)
+* [Further information](#further-information)
+
+# Kata Containers initrd image generation
+
+A Kata Containers initrd image is generated using the `initrd_builder.sh` script.
+This script uses a rootfs directory created by the `rootfs-builder/rootfs.sh` script.
+
+## Creating a guest OS initrd image
+
+To create a guest OS initrd image run:
+
+```
+$ sudo ./initrd_builder.sh path/to/rootfs
+```
+
+The `rootfs.sh` script populates the `path/to/rootfs` directory.
+
+## Further information
+
+For more information on how to use the `initrd_builder.sh` script, run:
+
+```
+$ ./initrd_builder.sh -h
+```

--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 HyperHQ Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+script_name="${0##*/}"
+script_dir="$(dirname $(readlink -f $0))"
+
+if [ -n "$DEBUG" ] ; then
+	set -x
+fi
+
+SCRIPT_NAME="${0##*/}"
+INITRD_IMAGE="${INITRD_IMAGE:-kata-initrd.img}"
+AGENT_BIN=${AGENT_BIN:-kata-agent}
+AGENT_INIT=${AGENT_INIT:-no}
+
+die()
+{
+	local msg="$*"
+	echo "ERROR: ${msg}" >&2
+	exit 1
+}
+
+OK()
+{
+	local msg="$*"
+	echo "[OK] ${msg}" >&2
+}
+
+info()
+{
+	local msg="$*"
+	echo "INFO: ${msg}"
+}
+
+usage()
+{
+	error="${1:-0}"
+	cat <<EOT
+Usage: ${SCRIPT_NAME} [options] <rootfs-dir>
+	This script creates a Kata Containers initrd image file based on the
+	<rootfs-dir> directory.
+
+Options:
+	-h Show help
+	-o Set the path where the generated image file is stored.
+	   DEFAULT: the path stored in the environment variable INITRD_IMAGE
+
+Extra environment variables:
+	AGENT_BIN:  use it to change the expected agent binary name
+		    DEFAULT: kata-agent
+	AGENT_INIT: use kata agent as init process
+		    DEFAULT: no
+	USE_DOCKER: If set, the image builds in a Docker Container. Setting
+		    this variable requires Docker.
+	            DEFAULT: not set
+EOT
+exit "${error}"
+}
+
+while getopts "ho:" opt
+do
+	case "$opt" in
+		h)	usage ;;
+		o)	INITRD_IMAGE="${OPTARG}" ;;
+	esac
+done
+
+shift $(( $OPTIND - 1 ))
+
+ROOTFS="$1"
+
+
+[ -n "${ROOTFS}" ] || usage
+[ -d "${ROOTFS}" ] || die "${ROOTFS} is not a directory"
+
+ROOTFS=$(readlink -f ${ROOTFS})
+IMAGE_DIR=$(dirname ${INITRD_IMAGE})
+IMAGE_DIR=$(readlink -f ${IMAGE_DIR})
+IMAGE_NAME=$(basename ${INITRD_IMAGE})
+
+# The kata rootfs image expects init to be installed
+init="${ROOTFS}/sbin/init"
+[ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
+OK "init is installed"
+[ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/bin/${AGENT_BIN}" ] || \
+	die "/bin/${AGENT_BIN} is not installed in ${ROOTFS}
+	use AGENT_BIN env variable to change the expected agent binary name"
+OK "Agent is installed"
+
+[ "$(id -u)" -eq 0 ] || die "$0: must be run as root"
+
+# initramfs expects /init
+mv -f ${init} "${ROOTFS}/init"
+
+info "Creating ${IMAGE_DIR}/${IMAGE_NAME} based on rootfs at ${ROOTFS}"
+( cd "${ROOTFS}" && find . | cpio -H newc -o | gzip -9 ) > "${IMAGE_DIR}"/"${IMAGE_NAME}"

--- a/rootfs-builder/README.md
+++ b/rootfs-builder/README.md
@@ -38,6 +38,8 @@ The rootfs must provide at least the following components:
 
   Path: `/sbin/init` - init binary called by the kernel.
 
+When `AGENT_INIT` environment variable is set to `yes`, use Kata agent as `/sbin/init`.
+
 ## Creating a rootfs
 
 To build a rootfs for your chosen distribution, run:

--- a/rootfs-builder/README.md
+++ b/rootfs-builder/README.md
@@ -1,5 +1,6 @@
 * [Supported base OSs](#supported-base-oss)
 * [Creating a rootfs](#creating-a-rootfs)
+* [Creating a rootfs with kernel modules](#creating-a-rootfs-with-kenrel-modules)
 * [Build a rootfs using Docker*](#build-a-rootfs-using-docker*)
 * [Adding support for a new guest OS](#adding-support-for-a-new-guest-os)
     * [Create template files](#create-template-files)
@@ -47,6 +48,15 @@ To build a rootfs for your chosen distribution, run:
 ```
 $ sudo ./rootfs.sh <distro>
 ```
+
+## Creating a rootfs with kernel modules
+
+To build a rootfs with additional kernel modules, run:
+```
+$ sudo KERNEL_MODULES_DIR=${kernel_mod_dir} ./rootfs.sh <distro>
+```
+Where `kernel_mod_dir` points to the kernel modules directory to be put under
+`/lib/modules/` directory of the created rootfs.
 
 ## Build a rootfs using Docker*
 

--- a/rootfs-builder/README.md
+++ b/rootfs-builder/README.md
@@ -39,7 +39,7 @@ The rootfs must provide at least the following components:
 
   Path: `/sbin/init` - init binary called by the kernel.
 
-When `AGENT_INIT` environment variable is set to `yes`, use Kata agent as `/sbin/init`.
+When the `AGENT_INIT` environment variable is set to `yes`, use Kata agent as `/sbin/init`.
 
 ## Creating a rootfs
 
@@ -55,7 +55,7 @@ To build a rootfs with additional kernel modules, run:
 ```
 $ sudo KERNEL_MODULES_DIR=${kernel_mod_dir} ./rootfs.sh <distro>
 ```
-Where `kernel_mod_dir` points to the kernel modules directory to be put under
+Where `kernel_mod_dir` points to the kernel modules directory to be put under the
 `/lib/modules/` directory of the created rootfs.
 
 ## Build a rootfs using Docker*

--- a/rootfs-builder/centos/config.sh
+++ b/rootfs-builder/centos/config.sh
@@ -9,7 +9,10 @@
 OS_VERSION=${OS_VERSION:-7}
 
 #Mandatory Packages that must be installed
-# systemd: An init system that will start kata-agent
 # iptables: Need by Kata agent
-# udevlib.so: Need by Kata agent
-PACKAGES="systemd iptables"
+PACKAGES="iptables"
+
+#Optional packages:
+# systemd: An init system that will start kata-agent if kata-agent
+#          itself is not configured as init process.
+[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true

--- a/rootfs-builder/centos/rootfs_lib.sh
+++ b/rootfs-builder/centos/rootfs_lib.sh
@@ -129,6 +129,7 @@ build_rootfs() {
 
 	DNF="${PKG_MANAGER} --config=$DNF_CONF -y --installroot=${ROOTFS_DIR} --noplugins"
 	$DNF install ${EXTRA_PKGS} ${PACKAGES}
+	$DNF clean all
 
 	[ -n "${ROOTFS_DIR}" ]  && rm -r "${ROOTFS_DIR}/var/cache/centos-osbuilder"
 }

--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -5,4 +5,5 @@
 
 #Use "latest" to always pull the last Clear Linux Release
 OS_VERSION=${OS_VERSION:-latest}
-PACKAGES="systemd iptables-bin libudev0-shim"
+PACKAGES="iptables-bin libudev0-shim"
+[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true

--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -9,7 +9,10 @@
 OS_VERSION=${OS_VERSION:-2.2}
 
 #Mandatory Packages that must be installed
-# systemd: An init system that will start kata-agent
 # iptables: Need by Kata agent
-# udevlib.so: Need by Kata agent
-PACKAGES="systemd iptables"
+PACKAGES="iptables"
+
+#Optional packages:
+# systemd: An init system that will start kata-agent if kata-agent
+#          itself is not configured as init process.
+[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -5,4 +5,5 @@
 
 #Fedora version to use
 OS_VERSION=${OS_VERSION:-27}
-PACKAGES="systemd iptables"
+PACKAGES="iptables"
+[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true

--- a/tests/image_creation.bats
+++ b/tests/image_creation.bats
@@ -7,6 +7,7 @@
 
 rootfs_sh="$BATS_TEST_DIRNAME/../rootfs-builder/rootfs.sh"
 image_builder_sh="$BATS_TEST_DIRNAME/../image-builder/image_builder.sh"
+initrd_builder_sh="$BATS_TEST_DIRNAME/../initrd-builder/initrd_builder.sh"
 readonly tmp_dir=$(mktemp -t -d osbuilder-test.XXXXXXX)
 #FIXME: Remove image size after https://github.com/kata-containers/osbuilder/issues/25 is fixed
 readonly image_size=400
@@ -23,27 +24,50 @@ teardown(){
 	rm -rf "${tmp_dir}"
 }
 
-function build_image()
+function build_rootfs()
 {
 	distro="$1"
 	[ -n "$distro" ]
 	local rootfs="${tmp_dir}/rootfs-osbuilder"
 	sudo -E ${rootfs_sh} -r "${rootfs}" "${distro}"
-	sudo ${image_builder_sh} -s ${image_size} -o "${tmp_dir}/image.img" "${rootfs}"
+}
+
+function build_image()
+{
+	distro="$1"
+	[ -n "$distro" ]
+	local rootfs="${tmp_dir}/rootfs-osbuilder"
+	sudo -E ${image_builder_sh} -s ${image_size} -o "${tmp_dir}/image.img" "${rootfs}"
+}
+
+function build_initrd()
+{
+	distro="$1"
+	[ -n "$distro" ]
+	local rootfs="${tmp_dir}/rootfs-osbuilder"
+	sudo -E ${initrd_builder_sh} -o "${tmp_dir}/initrd-image.img" "${rootfs}"
 }
 
 @test "Can create fedora image" {
+	build_rootfs fedora
 	build_image fedora
+	build_initrd fedora
 }
 
 @test "Can create clearlinux image" {
+	build_rootfs clearlinux
 	build_image clearlinux
+	build_initrd clearlinux
 }
 
 @test "Can create centos image" {
-	build_image centos 
+	build_rootfs centos
+	build_image centos
+	build_initrd centos
 }
 
 @test "Can create euleros image" {
+	build_rootfs euleros
 	build_image euleros
+	build_initrd euleros
 }


### PR DESCRIPTION
The kata agent can be used as init process and thus we do not always rely on systemd. Also created kata initrd image based on rootfs created by `rootfs.sh`.

fixes: #5 
fixes: #7 