### PR TITLE
alpine rootfs support

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -138,8 +138,8 @@ fi
 init="${ROOTFS}/sbin/init"
 [ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
 OK "init is installed"
-[ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/bin/${AGENT_BIN}" ] || \
-	die "/bin/${AGENT_BIN} is not installed in ${ROOTFS}
+[ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/usr/bin/${AGENT_BIN}" ] || \
+	die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}
 	use AGENT_BIN env variable to change the expected agent binary name"
 OK "Agent installed"
 [ "$(id -u)" -eq 0 ] || die "$0: must be run as root"

--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -87,8 +87,8 @@ IMAGE_NAME=$(basename ${INITRD_IMAGE})
 init="${ROOTFS}/sbin/init"
 [ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
 OK "init is installed"
-[ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/bin/${AGENT_BIN}" ] || \
-	die "/bin/${AGENT_BIN} is not installed in ${ROOTFS}
+[ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/usr/bin/${AGENT_BIN}" ] || \
+	die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}
 	use AGENT_BIN env variable to change the expected agent binary name"
 OK "Agent is installed"
 

--- a/rootfs-builder/alpine/Dockerfile.in
+++ b/rootfs-builder/alpine/Dockerfile.in
@@ -1,0 +1,3 @@
+From golang:@GO_VERSION@-alpine3.7
+
+RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static

--- a/rootfs-builder/alpine/config.sh
+++ b/rootfs-builder/alpine/config.sh
@@ -1,0 +1,23 @@
+# This is a configuration file add extra variables to
+# be used by build_rootfs() from rootfs_lib.sh the variables will be
+# loaded just before call the function.
+
+# Here there are a couple of variables you may need.
+# Remove them or add more
+
+# alpine version
+OS_VERSION=${OS_VERSION:-v3.7}
+
+# Essential base packages
+BASE_PACKAGES="alpine-base"
+
+# Alpine mirror to use
+# See a list of mirrors at http://nl.alpinelinux.org/alpine/MIRRORS.txt
+MIRROR=http://dl-5.alpinelinux.org/alpine
+
+# Default Architecture
+ARCH=${ARCH:-x86_64}
+
+# Mandatory Packages that must be installed
+#  - iptables: Need by Kata agent
+PACKAGES="iptables"

--- a/rootfs-builder/alpine/rootfs_lib.sh
+++ b/rootfs-builder/alpine/rootfs_lib.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 HyperHQ Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+check_root()
+{
+	if [ "$(id -u)" != "0" ]; then
+		echo "Root is needed"
+		exit 1
+	fi
+}
+
+# - Arguments
+# rootfs_dir=$1
+#
+# - Optional environment variables
+#
+# EXTRA_PKGS: Variable to add extra PKGS provided by the user
+#
+# BIN_AGENT: Name of the Kata-Agent binary
+#
+# Any other configuration variable for a specific distro must be added
+# and documented on its own config.sh
+#
+# - Expected result
+#
+# rootfs_dir populated with rootfs pkgs
+# It must provide a binary in /sbin/init
+build_rootfs() {
+	# Mandatory
+	local ROOTFS_DIR=$1
+
+	# In case of support EXTRA packages, use it to allow
+	# users add more packages to the base rootfs
+	local EXTRA_PKGS=${EXTRA_PKGS:-}
+
+	# Populate ROOTFS_DIR
+	check_root
+	mkdir -p "${ROOTFS_DIR}"
+
+	/sbin/apk.static \
+	    -X ${MIRROR}/${OS_VERSION}/main \
+	    -U \
+	    --allow-untrusted \
+	    --root ${ROOTFS_DIR}\
+	    --initdb add ${BASE_PACKAGES} ${EXTRA_PKGS} ${PACKAGES}
+
+	mkdir -p ${ROOTFS_DIR}{/root,/etc/apk,/proc}
+	echo "${MIRROR}/${OS_VERSION}/main" >  ${ROOTFS_DIR}/etc/apk/repositories
+}

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -104,6 +104,7 @@ ENV PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin
 	pushd ${dir}
 	[ -f "${dockerfile_template}" ] || die "${dockerfile_template}: file not found"
 	sed \
+		-e "s|@GO_VERSION@|${GO_VERSION}|g" \
 		-e "s|@OS_VERSION@|${OS_VERSION}|g" \
 		-e "s|@INSTALL_GO@|${install_go//$'\n'/\\n}|g" \
 		${dockerfile_template} > Dockerfile
@@ -209,6 +210,7 @@ OK "Pull Agent source code"
 
 info "Build agent"
 pushd "${GOPATH}/src/${GO_AGENT_PKG}"
+make clean
 make INIT=${AGENT_INIT}
 make install DESTDIR="${ROOTFS_DIR}" INIT=${AGENT_INIT}
 popd

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -212,10 +212,10 @@ pushd "${GOPATH}/src/${GO_AGENT_PKG}"
 make INIT=${AGENT_INIT}
 make install DESTDIR="${ROOTFS_DIR}" INIT=${AGENT_INIT}
 popd
-[ -x "${ROOTFS_DIR}/bin/${AGENT_BIN}" ] || die "/bin/${AGENT_BIN} is not installed in ${ROOTFS_DIR}"
+[ -x "${ROOTFS_DIR}/usr/bin/${AGENT_BIN}" ] || die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS_DIR}"
 OK "Agent installed"
 
-[ "${AGENT_INIT}" == "yes" ] && setup_agent_init "${ROOTFS_DIR}/bin/${AGENT_BIN}" "${init}"
+[ "${AGENT_INIT}" == "yes" ] && setup_agent_init "${ROOTFS_DIR}/usr/bin/${AGENT_BIN}" "${init}"
 
 info "Check init is installed"
 [ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"

--- a/tests/image_creation.bats
+++ b/tests/image_creation.bats
@@ -9,6 +9,7 @@ rootfs_sh="$BATS_TEST_DIRNAME/../rootfs-builder/rootfs.sh"
 image_builder_sh="$BATS_TEST_DIRNAME/../image-builder/image_builder.sh"
 initrd_builder_sh="$BATS_TEST_DIRNAME/../initrd-builder/initrd_builder.sh"
 readonly tmp_dir=$(mktemp -t -d osbuilder-test.XXXXXXX)
+tmp_rootfs="${tmp_dir}/rootfs-osbuilder"
 #FIXME: Remove image size after https://github.com/kata-containers/osbuilder/issues/25 is fixed
 readonly image_size=400
 
@@ -20,54 +21,50 @@ setup()
 
 teardown(){
 	# Rootfs is own by root change it to remove it
-	sudo rm -rf "${tmp_dir}/rootfs-osbuilder"
+	sudo rm -rf "${tmp_rootfs}"
 	rm -rf "${tmp_dir}"
 }
 
 function build_rootfs()
 {
-	distro="$1"
-	[ -n "$distro" ]
-	local rootfs="${tmp_dir}/rootfs-osbuilder"
-	sudo -E ${rootfs_sh} -r "${rootfs}" "${distro}"
+	sudo -E ${rootfs_sh} -r "${tmp_rootfs}" "${distro}"
 }
 
 function build_image()
 {
-	distro="$1"
-	[ -n "$distro" ]
-	local rootfs="${tmp_dir}/rootfs-osbuilder"
-	sudo -E ${image_builder_sh} -s ${image_size} -o "${tmp_dir}/image.img" "${rootfs}"
+	sudo -E ${image_builder_sh} -s ${image_size} -o "${tmp_dir}/image.img" "${tmp_rootfs}"
 }
 
 function build_initrd()
 {
+	sudo -E ${initrd_builder_sh} -o "${tmp_dir}/initrd-image.img" "${tmp_rootfs}"
+}
+
+function build_rootfs_image_initrd()
+{
 	distro="$1"
 	[ -n "$distro" ]
-	local rootfs="${tmp_dir}/rootfs-osbuilder"
-	sudo -E ${initrd_builder_sh} -o "${tmp_dir}/initrd-image.img" "${rootfs}"
+	build_rootfs $distro
+	build_image
+	build_initrd
 }
 
 @test "Can create fedora image" {
-	build_rootfs fedora
-	build_image fedora
-	build_initrd fedora
+	build_rootfs_image_initrd fedora
 }
 
 @test "Can create clearlinux image" {
-	build_rootfs clearlinux
-	build_image clearlinux
-	build_initrd clearlinux
+	build_rootfs_image_initrd clearlinux
 }
 
 @test "Can create centos image" {
-	build_rootfs centos
-	build_image centos
-	build_initrd centos
+	build_rootfs_image_initrd centos
 }
 
 @test "Can create euleros image" {
-	build_rootfs euleros
-	build_image euleros
-	build_initrd euleros
+	build_rootfs_image_initrd euleros
+}
+
+@test "Can create alpine image" {
+	build_rootfs_image_initrd alpine
 }


### PR DESCRIPTION
This PR adds alpine rootfs support so that we can get much smaller rootfs image and initrd image.
For example, I got 8.5MB kata-initrd.img with alpine rootfs in contrast of 50+MB centos rootfs.

This is based on top of #49 and I'll rebase once that one gets merged.