### PR TITLE
scripts : handle 0 and negative root disk sizes

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -85,7 +85,7 @@ do
 		h)	usage ;;
 		o)	IMAGE="${OPTARG}" ;;
 		s)	IMG_SIZE=${OPTARG}
-                        if [ ${IMG_SIZE} -lt 0 ]; then
+                        if [ ${IMG_SIZE} -le 0 ]; then
                                 die "Image size has to be greater than 0 MB."
                         fi
                         if [ ${IMG_SIZE} -gt ${MAX_IMG_SIZE_MB} ]; then


### PR DESCRIPTION
When user manually specifies root disk image
size the value should be greater than 0.

Fixes : #57

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>