### PR TITLE
CI: Make setup script fail on error

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -e
+
 cidir=$(dirname "$0")
 bash "${cidir}/static-checks.sh"
 


### PR DESCRIPTION
Run the `.ci/setup.sh` script with `set -e` to ensure all failures are
fatal.

Fixes #65.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>