### PR TITLE
allow to build image and initrd based on existing rootfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,19 @@ DISTRO_ROOTFS := "$(PWD)/$(DISTRO)_rootfs"
 IMG_SIZE=500
 AGENT_INIT ?= no
 
+all: rootfs image initrd
 rootfs:
 	@echo Creating rootfs based on "$(DISTRO)"
 	"$(MK_DIR)/rootfs-builder/rootfs.sh" -r "$(DISTRO_ROOTFS)" "$(DISTRO)"
 
-image: rootfs
+image: rootfs image-only
+
+image-only:
 	@echo Creating image based on "$(DISTRO_ROOTFS)"
 	"$(MK_DIR)/image-builder/image_builder.sh" -s "$(IMG_SIZE)" "$(DISTRO_ROOTFS)"
 
-initrd: rootfs
+initrd: rootfs initrd-only
+
+initrd-only:
 	@echo Creating initrd image based on "$(DISTRO_ROOTFS)"
 	"$(MK_DIR)/initrd-builder/initrd_builder.sh" "$(DISTRO_ROOTFS)"

--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -85,7 +85,7 @@ IMAGE_NAME=$(basename ${INITRD_IMAGE})
 
 # The kata rootfs image expects init to be installed
 init="${ROOTFS}/sbin/init"
-[ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
+[ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS}"
 OK "init is installed"
 [ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/usr/bin/${AGENT_BIN}" ] || \
 	die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}


### PR DESCRIPTION
Just so that we do not have to re-build rootfs every time for local build/testing.