### PR TITLE
Install the right golang binaries for ppc64le

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -93,6 +93,10 @@ generate_dockerfile() {
 	dir="$1"
 
 	case "$(arch)" in
+		"ppc64le")
+			goarch=ppc64le
+			;;
+
 		"aarch64")
 			goarch=arm64
 			;;


### PR DESCRIPTION
Install the right golang binaries for ppc64le

Fixes #72

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>