### PR TITLE
initrd-builder: fix initrd image name

### DIFF
--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -14,7 +14,7 @@ if [ -n "$DEBUG" ] ; then
 fi
 
 SCRIPT_NAME="${0##*/}"
-INITRD_IMAGE="${INITRD_IMAGE:-kata-initrd.img}"
+INITRD_IMAGE="${INITRD_IMAGE:-kata-containers-initrd.img}"
 AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
 


### PR DESCRIPTION
The initrd image name should be kata-containers-initrd.img, as its referenced by this name later on.

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>