### PR TITLE
refactor and create a summary file inside the image

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -14,12 +14,13 @@ bash "${cidir}/static-checks.sh"
 source /etc/os-release
 
 if [ "$ID" == fedora ];then
-	sudo -E dnf -y install automake  bats
+	sudo -E dnf -y install automake bats yamllint
 elif [ "$ID" == ubuntu ];then
 	#bats isn't available for Ubuntu trusty, need for travis
 	sudo add-apt-repository -y ppa:duggan/bats
 	sudo apt-get -qq update
-	sudo apt-get install -y -qq automake bats qemu-utils
+	sudo apt-get install -y -qq automake bats qemu-utils python-pip
+	sudo pip install yamllint
 else 
 	echo "Linux distribution not supported"
 fi

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,16 @@ DISTRO_ROOTFS := "$(PWD)/$(DISTRO)_rootfs"
 IMG_SIZE=500
 AGENT_INIT ?= no
 
+VERSION_FILE := ./VERSION
+VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
+
 all: rootfs image initrd
 rootfs:
 	@echo Creating rootfs based on "$(DISTRO)"
-	"$(MK_DIR)/rootfs-builder/rootfs.sh" -r "$(DISTRO_ROOTFS)" "$(DISTRO)"
+	"$(MK_DIR)/rootfs-builder/rootfs.sh" -o $(VERSION_COMMIT) -r "$(DISTRO_ROOTFS)" "$(DISTRO)"
 
 image: rootfs image-only
 

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,2 @@
+# This is the version of osbuilder.
+0.0.1

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -11,7 +11,6 @@ set -e
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"
 
-SCRIPT_NAME="${0##*/}"
 IMAGE="${IMAGE:-kata-containers.img}"
 AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
@@ -45,7 +44,7 @@ usage()
 {
 	error="${1:-0}"
 	cat <<EOT
-Usage: ${SCRIPT_NAME} [options] <rootfs-dir>
+Usage: ${script_name} [options] <rootfs-dir>
 	This script will create a Kata Containers image file of
         an adequate size based on the <rootfs-dir> directory.
         The size of the image can be also be specified manually

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -6,12 +6,10 @@
 
 set -e
 
+[ -n "$DEBUG" ] && set -x
+
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"
-
-if [ -n "$DEBUG" ] ; then
-	set -x
-fi
 
 SCRIPT_NAME="${0##*/}"
 IMAGE="${IMAGE:-kata-containers.img}"

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -104,6 +104,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 		--env AGENT_INIT=${AGENT_INIT} \
 		-v /dev:/dev \
 		-v "${script_dir}":"/osbuilder" \
+		-v "${script_dir}/../scripts":"/scripts" \
 		-v "${ROOTFS}":"/rootfs" \
 		-v "${IMAGE_DIR}":"/image" \
 		${image_name} \

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -113,7 +113,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 fi
 # The kata rootfs image expect init and kata-agent to be installed
 init="${ROOTFS}/sbin/init"
-[ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
+[ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS}"
 OK "init is installed"
 [ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/usr/bin/${AGENT_BIN}" ] || \
 	die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -11,34 +11,12 @@ set -e
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"
 
+lib_file="${script_dir}/../scripts/lib.sh"
+source "$lib_file"
+
 IMAGE="${IMAGE:-kata-containers.img}"
 AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
-
-die()
-{
-	local msg="$*"
-	echo "ERROR: ${msg}" >&2
-	exit 1
-}
-
-OK()
-{
-	local msg="$*"
-	echo "[OK] ${msg}" >&2
-}
-
-info()
-{
-	local msg="$*"
-	echo "INFO: ${msg}"
-}
-
-warning()
-{
-        local msg="$*"
-        echo "WARNING: ${msg}"
-}
 
 usage()
 {

--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -6,12 +6,10 @@
 
 set -e
 
+[ -n "$DEBUG" ] && set -x
+
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"
-
-if [ -n "$DEBUG" ] ; then
-	set -x
-fi
 
 SCRIPT_NAME="${0##*/}"
 INITRD_IMAGE="${INITRD_IMAGE:-kata-containers-initrd.img}"

--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -36,9 +36,6 @@ Extra environment variables:
 		    DEFAULT: kata-agent
 	AGENT_INIT: use kata agent as init process
 		    DEFAULT: no
-	USE_DOCKER: If set, the image builds in a Docker Container. Setting
-		    this variable requires Docker.
-	            DEFAULT: not set
 EOT
 exit "${error}"
 }

--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -11,28 +11,12 @@ set -e
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"
 
+lib_file="${script_dir}/../scripts/lib.sh"
+source "$lib_file"
+
 INITRD_IMAGE="${INITRD_IMAGE:-kata-containers-initrd.img}"
 AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
-
-die()
-{
-	local msg="$*"
-	echo "ERROR: ${msg}" >&2
-	exit 1
-}
-
-OK()
-{
-	local msg="$*"
-	echo "[OK] ${msg}" >&2
-}
-
-info()
-{
-	local msg="$*"
-	echo "INFO: ${msg}"
-}
 
 usage()
 {

--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -11,7 +11,6 @@ set -e
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"
 
-SCRIPT_NAME="${0##*/}"
 INITRD_IMAGE="${INITRD_IMAGE:-kata-containers-initrd.img}"
 AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
@@ -39,7 +38,7 @@ usage()
 {
 	error="${1:-0}"
 	cat <<EOT
-Usage: ${SCRIPT_NAME} [options] <rootfs-dir>
+Usage: ${script_name} [options] <rootfs-dir>
 	This script creates a Kata Containers initrd image file based on the
 	<rootfs-dir> directory.
 

--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -4,12 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 OS_NAME="Clear"
+REPO_NAME="clear"
 
 OS_VERSION=${OS_VERSION:-latest}
 
-BASE_URL="https://download.clearlinux.org/current/${ARCH}/os/"
+clr_url="https://download.clearlinux.org"
 
-REPO_NAME="clear"
+# resolve version
+[ "${OS_VERSION}" = "latest" ] && OS_VERSION=$(curl -sL "${clr_url}/latest")
+
+BASE_URL="${clr_url}/releases/${OS_VERSION}/${REPO_NAME}/${ARCH}/os/"
 
 PACKAGES="iptables-bin libudev0-shim"
 

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -16,6 +16,9 @@ AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
 KERNEL_MODULES_DIR=${KERNEL_MODULES_DIR:-""}
 
+lib_file="${script_dir}/../scripts/lib.sh"
+source "$lib_file"
+
 # Default architecture
 ARCH=${ARCH:-"x86_64"}
 
@@ -58,25 +61,6 @@ KERNEL_MODULES_DIR: Optional kernel modules to put into the rootfs.
 		    DEFAULT: ""
 EOT
 exit "${error}"
-}
-
-die()
-{
-	msg="$*"
-	echo "ERROR: ${msg}" >&2
-	exit 1
-}
-
-info()
-{
-	msg="$*"
-	echo "INFO: ${msg}" >&2
-}
-
-OK()
-{
-	msg="$*"
-	echo "INFO: [OK] ${msg}" >&2
 }
 
 get_distros() {
@@ -173,10 +157,6 @@ distro_config_dir="${script_dir}/${distro}"
 # Source config.sh from distro
 rootfs_config="${distro_config_dir}/${CONFIG_SH}"
 source "${rootfs_config}"
-
-lib_file="${script_dir}/../scripts/lib.sh"
-info "Source $lib_file"
-[ -e "$lib_file" ] && source "$lib_file" || true
 
 [ -d "${distro_config_dir}" ] || die "Not found configuration directory ${distro_config_dir}"
 

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -49,6 +49,7 @@ $(get_distros)
 Options:
 -a  : agent version DEFAULT: ${AGENT_VERSION} ENV: AGENT_VERSION 
 -h  : Show this help message
+-o  : specify version of osbuilder
 -r  : rootfs directory DEFAULT: ${ROOTFS_DIR} ENV: ROOTFS_DIR
 
 ENV VARIABLES:
@@ -144,11 +145,14 @@ copy_kernel_modules()
 	OK "Kernel modules copied"
 }
 
-while getopts c:hr: opt
+OSBUILDER_VERSION="unknown"
+
+while getopts c:ho:r: opt
 do
 	case $opt in
 		a)	AGENT_VERSION="${OPTARG}" ;;
 		h)	usage ;;
+		o)	OSBUILDER_VERSION="${OPTARG}" ;;
 		r)	ROOTFS_DIR="${OPTARG}" ;;
 	esac
 done
@@ -160,6 +164,8 @@ shift $(($OPTIND - 1))
 [ "$AGENT_INIT" == "yes" -o "$AGENT_INIT" == "no" ] || die "AGENT_INIT($AGENT_INIT) is invalid (must be yes or no)"
 
 [ -n "${KERNEL_MODULES_DIR}" ] && [ ! -d "${KERNEL_MODULES_DIR}" ] && die "KERNEL_MODULES_DIR defined but is not an existing directory"
+
+[ -z "${OSBUILDER_VERSION}" ] && die "need osbuilder version"
 
 distro="$1"
 
@@ -214,6 +220,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 		--env GOPATH="${GOPATH}" \
 		--env KERNEL_MODULES_DIR="${KERNEL_MODULES_DIR}" \
 		--env EXTRA_PKGS="${EXTRA_PKGS}" \
+		--env OSBUILDER_VERSION="${OSBUILDER_VERSION}" \
 		-v "${script_dir}":"/osbuilder" \
 		-v "${ROOTFS_DIR}":"/rootfs" \
 		-v "${script_dir}/../scripts":"/scripts" \
@@ -251,3 +258,6 @@ OK "Agent installed"
 info "Check init is installed"
 [ -x "${init}" ] || [ -L "${init}" ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
 OK "init is installed"
+
+info "Creating summary file"
+create_summary_file "${ROOTFS_DIR}"

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -22,16 +22,17 @@ source "$lib_file"
 # Default architecture
 ARCH=${ARCH:-"x86_64"}
 
-#Load default vesions for golang and other componets
+# Load default versions for golang and other componets
 source "${script_dir}/versions.txt"
 
-# config file
+# distro-specific config file
 typeset -r CONFIG_SH="config.sh"
 
-# Name of the extra file that could implement build_rootfs
+# Name of an optional distro-specific file which, if it exists, must implement the
+# build_rootfs() function.
 typeset -r LIB_SH="rootfs_lib.sh"
 
-#$1: Error code if want to exit differnt to 0
+#$1: Error code if want to exit different to 0
 usage(){
 	error="${1:-0}"
 	cat <<EOT

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -6,6 +6,8 @@
 
 set -e
 
+[ -n "$DEBUG" ] && set -x
+
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"
 AGENT_VERSION=${AGENT_VERSION:-master}
@@ -25,10 +27,6 @@ typeset -r CONFIG_SH="config.sh"
 
 # Name of the extra file that could implement build_rootfs
 typeset -r LIB_SH="rootfs_lib.sh"
-
-if [ -n "$DEBUG" ] ; then
-	set -x
-fi
 
 #$1: Error code if want to exit differnt to 0
 usage(){

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -240,10 +240,13 @@ make clean
 make INIT=${AGENT_INIT}
 make install DESTDIR="${ROOTFS_DIR}" INIT=${AGENT_INIT}
 popd
-[ -x "${ROOTFS_DIR}/usr/bin/${AGENT_BIN}" ] || die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS_DIR}"
+
+AGENT_DIR="${ROOTFS_DIR}/usr/bin"
+AGENT_DEST="${AGENT_DIR}/${AGENT_BIN}"
+[ -x "${AGENT_DEST}" ] || die "${AGENT_DEST} is not installed in ${ROOTFS_DIR}"
 OK "Agent installed"
 
-[ "${AGENT_INIT}" == "yes" ] && setup_agent_init "${ROOTFS_DIR}/usr/bin/${AGENT_BIN}" "${init}"
+[ "${AGENT_INIT}" == "yes" ] && setup_agent_init "${AGENT_DEST}" "${init}"
 
 info "Check init is installed"
 [ -x "${init}" ] || [ -L "${init}" ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -136,9 +136,11 @@ copy_kernel_modules()
 	[ -z "$module_dir" ] && die "need module directory"
 	[ -z "$rootfs_dir" ] && die "need rootfs directory"
 
+	local destdir="${rootfs_dir}/lib/modules"
+
 	info "Copy kernel modules from ${KERNEL_MODULES_DIR}"
-	mkdir -p ${rootfs_dir}/lib/modules/
-	cp -a ${KERNEL_MODULES_DIR} ${rootfs_dir}/lib/modules/
+	mkdir -p "${destdir}"
+	cp -a "${KERNEL_MODULES_DIR}" "${dest_dir}/"
 	OK "Kernel modules copied"
 }
 

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -119,6 +119,10 @@ setup_agent_init()
 {
 	agent_bin="$1"
 	init_bin="$2"
+
+	[ -z "$agent_bin" ] && die "need agent binary path"
+	[ -z "$init_bin" ] && die "need init bin path"
+
 	info "Install $agent_bin as init process"
 	mv -f "${agent_bin}" ${init_bin}
 	OK "Agent is installed as init process"
@@ -126,10 +130,11 @@ setup_agent_init()
 
 copy_kernel_modules()
 {
-	local module_dir=$1
-	local rootfs_dir=$2
+	local module_dir="$1"
+	local rootfs_dir="$2"
 
-	[ -z "module_dir" -o -z "rootfs_dir" ] && die "module dir and rootfs dir must be specified"
+	[ -z "$module_dir" ] && die "need module directory"
+	[ -z "$rootfs_dir" ] && die "need rootfs directory"
 
 	info "Copy kernel modules from ${KERNEL_MODULES_DIR}"
 	mkdir -p ${rootfs_dir}/lib/modules/

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -33,7 +33,8 @@ typeset -r CONFIG_SH="config.sh"
 typeset -r LIB_SH="rootfs_lib.sh"
 
 #$1: Error code if want to exit different to 0
-usage(){
+usage()
+{
 	error="${1:-0}"
 	cat <<EOT
 USAGE: Build a Guest OS rootfs for Kata Containers image
@@ -71,13 +72,14 @@ get_distros() {
 	done
 }
 
-
-check_function_exist() {
+check_function_exist()
+{
 	function_name="$1"
 	[ "$(type -t ${function_name})" == "function" ] || die "${function_name} function was not defined"
 }
 
-generate_dockerfile() {
+generate_dockerfile()
+{
 	dir="$1"
 
 	case "$(arch)" in
@@ -113,7 +115,8 @@ ENV PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin
 	popd
 }
 
-setup_agent_init() {
+setup_agent_init()
+{
 	agent_bin="$1"
 	init_bin="$2"
 	info "Install $agent_bin as init process"
@@ -121,7 +124,8 @@ setup_agent_init() {
 	OK "Agent is installed as init process"
 }
 
-copy_kernel_modules() {
+copy_kernel_modules()
+{
 	local module_dir=$1
 	local rootfs_dir=$2
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -6,7 +6,33 @@
 
 set -e
 
-check_program(){
+die()
+{
+	local msg="$*"
+	echo "ERROR: ${msg}" >&2
+	exit 1
+}
+
+OK()
+{
+	local msg="$*"
+	echo "[OK] ${msg}" >&2
+}
+
+info()
+{
+	local msg="$*"
+	echo "INFO: ${msg}"
+}
+
+warning()
+{
+	local msg="$*"
+	echo "WARNING: ${msg}"
+}
+
+check_program()
+{
 	type "$1" >/dev/null 2>&1
 }
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -62,7 +62,7 @@ reposdir=/root/mash
 retries=5
 EOF
 	if [ "$BASE_URL" != "" ]; then
-            cat >> "${DNF_CONF}" << EOF
+		cat >> "${DNF_CONF}" << EOF
 
 [base]
 name=${OS_NAME}-${OS_VERSION} ${REPO_NAME}
@@ -71,7 +71,7 @@ baseurl=${BASE_URL}
 enabled=1
 EOF
 	elif [ "$MIRROR_LIST" != "" ]; then
-	    cat >> "${DNF_CONF}" << EOF
+		cat >> "${DNF_CONF}" << EOF
 
 [base]
 name=${OS_NAME}-${OS_VERSION} ${REPO_NAME}
@@ -81,13 +81,12 @@ EOF
 	fi
 
 	if [ "$GPG_KEY_FILE" != "" ]; then
-            cat >> "${DNF_CONF}" << EOF
+		cat >> "${DNF_CONF}" << EOF
 gpgcheck=1
 gpgkey=file://${CONFIG_DIR}/${GPG_KEY_FILE}
 
 EOF
 	fi
-
 }
 
 build_rootfs()

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -94,6 +94,8 @@ build_rootfs()
 	# Mandatory
 	local ROOTFS_DIR="$1"
 
+	[ -z "$ROOTFS_DIR" ] && die "need rootfs"
+
 	# In case of support EXTRA packages, use it to allow
 	# users add more packages to the base rootfs
 	local EXTRA_PKGS=${EXTRA_PKGS:-""}

--- a/tests/image_creation.bats
+++ b/tests/image_creation.bats
@@ -27,7 +27,12 @@ teardown(){
 
 function build_rootfs()
 {
+	local file="/var/lib/osbuilder/osbuilder.yaml"
+	local full="${tmp_rootfs}${file}"
+
 	sudo -E ${rootfs_sh} -r "${tmp_rootfs}" "${distro}"
+
+	yamllint "${full}"
 }
 
 function build_image()


### PR DESCRIPTION
Create a compressed YAML metadata file inside the rootfs image
containing information about the environment:

```
/var/lib/osbuilder/osbuilder.yaml.gz
```

Example contents:

```
---
osbuilder:
url: "https://github.com/kata-containers/osbuilder"
version: "unknown"
rootfs-creation-time: "2018-04-19T16:19:30.254610305+0000Z"
description: "osbuilder rootfs"
file-format-version: "0.0.1"
architecture: "x86_64"
base-distro:
name: "Centos"
version: "7"
packages:
- "iptables"
- "systemd"
agent:
url: "https://github.com/kata-containers/agent"
name: "kata-agent"
version: "0.0.1-2ec0b9593845b9a5e0eab5a85b20d74c35a2ca52-dirty"
agent-is-init-daemon: "no"
```

This change adds a new `-o` option to `rootfs.sh` for
specifying the version of osbuilder to the rootfs builder.

Fixes #35.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>