### PR TITLE
rootfs.sh: Add "${AGENT_VERSION}"/"-a" functionality

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -147,7 +147,7 @@ copy_kernel_modules()
 
 OSBUILDER_VERSION="unknown"
 
-while getopts c:ho:r: opt
+while getopts a:ho:r: opt
 do
 	case $opt in
 		a)	AGENT_VERSION="${OPTARG}" ;;

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -246,6 +246,7 @@ OK "Pull Agent source code"
 
 info "Build agent"
 pushd "${GOPATH_LOCAL}/src/${GO_AGENT_PKG}"
+[ -n "${AGENT_VERSION}" ] && git checkout "${AGENT_VERSION}" && OK "git checkout successful" || true
 make clean
 make INIT=${AGENT_INIT}
 make install DESTDIR="${ROOTFS_DIR}" INIT=${AGENT_INIT}


### PR DESCRIPTION
For now, the flag "-a" or relevant shell variant "${AGENT_VERSION}" hasn't been used, only defined. Using 'git checkout' command to go into requested branch.
    
Fixes: #90
    
Signed-off-by: Penny Zheng <penny.zheng@arm.com>