### PR TITLE
rootfs: copy kernel modules to correct location

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -137,10 +137,10 @@ copy_kernel_modules()
 	[ -z "$module_dir" ] && die "need module directory"
 	[ -z "$rootfs_dir" ] && die "need rootfs directory"
 
-	local destdir="${rootfs_dir}/lib/modules"
+	local dest_dir="${rootfs_dir}/lib/modules"
 
 	info "Copy kernel modules from ${KERNEL_MODULES_DIR}"
-	mkdir -p "${destdir}"
+	mkdir -p "${dest_dir}"
 	cp -a "${KERNEL_MODULES_DIR}" "${dest_dir}/"
 	OK "Kernel modules copied"
 }


### PR DESCRIPTION
Commit b8f1a688340c7b1cfe5a1cb1bbe6a792dc97acf8 ("rootfs: Simplify
code") introduced a variable called destdir but accidentally used
dest_dir with cp(1) instead.  This causes kernel modules to be copied to
the wrong location.

Rename the variable to dest_dir to be consistent with module_dir and
rootfs_dir variables used in this function.

Fixes: #94
Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>