### PR TITLE
Image require systemd

### DIFF
--- a/image-builder/README.md
+++ b/image-builder/README.md
@@ -16,6 +16,9 @@ $ sudo ./image_builder.sh path/to/rootfs
 
 Where `path/to/rootfs` is the directory populated by `rootfs.sh`.
 
+> **Note**: If you are building an image from an Alpine rootfs, see
+> the important note [here](rootfs-builder/README.md#rootfs-requirements).
+
 ## Further information
 
 For more information about usage (including how to adjust the size of the

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -117,6 +117,15 @@ init_path="/sbin/init"
 init="${ROOTFS}${init_path}"
 [ -x "${init}" ] || [ -L ${init} ] || die "${init_path} is not installed in ${ROOTFS}"
 OK "init is installed"
+
+if [ "${AGENT_INIT}" == "no" ]
+then
+	systemd_path="/lib/systemd/systemd"
+	systemd="${ROOTFS}${systemd_path}"
+	[ -x "${systemd}" ] || [ -L ${systemd} ] || die "${systemd_path} is not installed in ${ROOTFS}"
+	OK "init is systemd"
+fi
+
 [ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/usr/bin/${AGENT_BIN}" ] || \
 	die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}
 	use AGENT_BIN env variable to change the expected agent binary name"

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -113,8 +113,9 @@ if [ -n "${USE_DOCKER}" ] ; then
 	exit $?
 fi
 # The kata rootfs image expect init and kata-agent to be installed
-init="${ROOTFS}/sbin/init"
-[ -x "${init}" ] || [ -L ${init} ] || die "/sbin/init is not installed in ${ROOTFS}"
+init_path="/sbin/init"
+init="${ROOTFS}${init_path}"
+[ -x "${init}" ] || [ -L ${init} ] || die "${init_path} is not installed in ${ROOTFS}"
 OK "init is installed"
 [ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/usr/bin/${AGENT_BIN}" ] || \
 	die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}

--- a/rootfs-builder/README.md
+++ b/rootfs-builder/README.md
@@ -41,6 +41,9 @@ The rootfs must provide at least the following components:
 
 When the `AGENT_INIT` environment variable is set to `yes`, use Kata agent as `/sbin/init`.
 
+> **Note**: `AGENT_INIT=yes` **must** be used for the Alpine distribution
+> since it does not use `systemd` as its init daemon.
+
 ## Creating a rootfs
 
 To build a rootfs for your chosen distribution, run:

--- a/tests/image_creation.bats
+++ b/tests/image_creation.bats
@@ -48,22 +48,26 @@ function build_initrd()
 function build_rootfs_image_initrd()
 {
 	distro="$1"
+	image="$2"
+	initrd="$3"
+
 	[ -n "$distro" ]
 	build_rootfs $distro
-	build_image
-	build_initrd
+
+	[ "$image" = "yes" ] && build_image
+	[ "$initrd" = "yes" ] && build_initrd
 }
 
 @test "Can create fedora image" {
-	build_rootfs_image_initrd fedora
+	build_rootfs_image_initrd fedora yes yes
 }
 
 @test "Can create clearlinux image" {
-	build_rootfs_image_initrd clearlinux
+	build_rootfs_image_initrd clearlinux yes yes
 }
 
 @test "Can create centos image" {
-	build_rootfs_image_initrd centos
+	build_rootfs_image_initrd centos yes yes
 }
 
 @test "Can create euleros image" {
@@ -71,9 +75,9 @@ function build_rootfs_image_initrd()
 	then
 		skip "travis timeout, see: https://github.com/kata-containers/osbuilder/issues/46"
 	fi
-	build_rootfs_image_initrd euleros
+	build_rootfs_image_initrd euleros yes yes
 }
 
 @test "Can create alpine image" {
-	build_rootfs_image_initrd alpine
+	build_rootfs_image_initrd alpine no yes
 }


### PR DESCRIPTION
Building an image requires systemd to be installed in the rootfs as the
init daemon, so assert that systemd is available.

Fixes #98.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>