### PR TITLE
rootfs: Default to host architecture

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -14,12 +14,12 @@ bash "${cidir}/static-checks.sh"
 source /etc/os-release
 
 if [ "$ID" == fedora ];then
-	sudo -E dnf -y install automake bats yamllint
+	sudo -E dnf -y install automake bats yamllint coreutils
 elif [ "$ID" == ubuntu ];then
 	#bats isn't available for Ubuntu trusty, need for travis
 	sudo add-apt-repository -y ppa:duggan/bats
 	sudo apt-get -qq update
-	sudo apt-get install -y -qq automake bats qemu-utils python-pip
+	sudo apt-get install -y -qq automake bats qemu-utils python-pip coreutils
 	sudo pip install yamllint
 else 
 	echo "Linux distribution not supported"

--- a/rootfs-builder/alpine/Dockerfile.in
+++ b/rootfs-builder/alpine/Dockerfile.in
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2018 HyperHQ Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 From golang:@GO_VERSION@-alpine3.7
 
-RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static
+# The "coreutils" package on alpine for reasons unknown does not provide arch(1), so simulate it.
+RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static && \
+    echo -e '#!/bin/sh\nuname -m' > /usr/bin/arch && chmod +x /usr/bin/arch

--- a/rootfs-builder/centos/Dockerfile.in
+++ b/rootfs-builder/centos/Dockerfile.in
@@ -1,6 +1,11 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 From centos:@OS_VERSION@
 
-RUN yum -y update && yum install -y git make gcc
+RUN yum -y update && yum install -y git make gcc coreutils
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -1,6 +1,11 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 From fedora:27
 
-RUN dnf -y update && dnf install -y git systemd pkgconfig gcc
+RUN dnf -y update && dnf install -y git systemd pkgconfig gcc coreutils
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/euleros/Dockerfile.in
+++ b/rootfs-builder/euleros/Dockerfile.in
@@ -1,5 +1,11 @@
+#
+# Copyright (C) 2018 Huawei Technologies Co., Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM euleros:@OS_VERSION@
 
-RUN yum -y update && yum install -y yum git make gcc
+RUN yum -y update && yum install -y yum git make gcc coreutils
+
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/fedora/Dockerfile.in
+++ b/rootfs-builder/fedora/Dockerfile.in
@@ -1,6 +1,11 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 From fedora:@OS_VERSION@
 
-RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc
+RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc coreutils
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -20,7 +20,7 @@ lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
 
 # Default architecture
-ARCH=${ARCH:-"x86_64"}
+ARCH=$(arch)
 
 # Load default versions for golang and other componets
 source "${script_dir}/versions.txt"

--- a/rootfs-builder/template/Dockerfile.template
+++ b/rootfs-builder/template/Dockerfile.template
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #@distro@: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
 from @distro@:@OS_VERSION@


### PR DESCRIPTION
Don't default to a hard-coded Intel architecture - default to the host
architecture.

Fixes #100.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>