### PR TITLE
CI: use yum for resolving centos dependencies

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -23,3 +23,8 @@ run_static_checks()
 	clone_tests_repo
 	bash "$tests_repo_dir/.ci/static-checks.sh"
 }
+
+install_bats()
+{
+	bash "$tests_repo_dir/.ci/install_bats.sh"
+}

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -8,20 +8,22 @@
 set -e
 
 cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
 bash "${cidir}/static-checks.sh"
 
 #Note: If add clearlinux as supported CI use a stateless os-release file
 source /etc/os-release
 
+install_bats
+
 if [ "$ID" == fedora ];then
-	sudo -E dnf -y install automake bats yamllint coreutils moreutils
+	sudo -E dnf -y install automake yamllint coreutils moreutils
 elif [ "$ID" == centos ];then
-	sudo -E yum -y install automake bats yamllint coreutils moreutils
+	sudo -E yum -y install automake yamllint coreutils moreutils
 elif [ "$ID" == ubuntu ];then
-	#bats isn't available for Ubuntu trusty, need for travis
-	sudo add-apt-repository -y ppa:duggan/bats
 	sudo apt-get -qq update
-	sudo apt-get install -y -qq automake bats qemu-utils python-pip coreutils moreutils
+	sudo apt-get install -y -qq automake qemu-utils python-pip coreutils moreutils
 	sudo pip install yamllint
 else 
 	echo "Linux distribution not supported"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -16,7 +16,7 @@ source /etc/os-release
 if [ "$ID" == fedora ];then
 	sudo -E dnf -y install automake bats yamllint coreutils moreutils
 elif [ "$ID" == centos ];then
-	sudo -E dnf -y install automake bats yamllint coreutils moreutils
+	sudo -E yum -y install automake bats yamllint coreutils moreutils
 elif [ "$ID" == ubuntu ];then
 	#bats isn't available for Ubuntu trusty, need for travis
 	sudo add-apt-repository -y ppa:duggan/bats

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -20,6 +20,7 @@ install_bats
 if [ "$ID" == fedora ];then
 	sudo -E dnf -y install automake yamllint coreutils moreutils
 elif [ "$ID" == centos ];then
+	sudo -E yum -y install epel-release
 	sudo -E yum -y install automake yamllint coreutils moreutils
 elif [ "$ID" == ubuntu ];then
 	sudo apt-get -qq update


### PR DESCRIPTION
`.ci/setup.sh` is using dnf instead of yum to install
centos dependencies. This fixes it to use yum.

Fixes: #104.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>