### PR TITLE
tests: Update kata-manager command

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -23,8 +23,3 @@ run_static_checks()
 	clone_tests_repo
 	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/osbuilder"
 }
-
-install_bats()
-{
-	bash "$tests_repo_dir/.ci/install_bats.sh"
-}

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -12,4 +12,4 @@ export GOPATH="${GOPATH:-/tmp/go}"
 
 script_dir="$(dirname $(readlink -f $0))"
 
-sudo -E PATH="$PATH" bats "${script_dir}/../tests/image_creation.bats"
+sudo -E PATH="$PATH" bash "${script_dir}/../tests/image_creation.sh"

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -15,8 +15,6 @@ bash "${cidir}/static-checks.sh"
 #Note: If add clearlinux as supported CI use a stateless os-release file
 source /etc/os-release
 
-install_bats
-
 if [ "$ID" == fedora ];then
 	sudo -E dnf -y install automake yamllint coreutils moreutils
 elif [ "$ID" == centos ];then

--- a/tests/image_creation.bats
+++ b/tests/image_creation.bats
@@ -51,7 +51,7 @@ setup()
 
 	[ ! -d "${tests_repo_dir}" ] && git clone "https://${tests_repo}" "${tests_repo_dir}"
 
-	chronic $mgr install-packages
+	chronic $mgr install-docker-system
 	chronic $mgr enable-debug
 
 	# Ensure "docker build" works

--- a/tests/image_creation.sh
+++ b/tests/image_creation.sh
@@ -353,8 +353,11 @@ main()
 	test_fedora
 	test_clearlinux
 	test_centos
-	test_euleros
 	test_alpine
+
+	# Run last as EulerOS servers can be slow and we don't want to fail the
+	# previous tests.
+	test_euleros
 }
 
 main "$@"


### PR DESCRIPTION
The `kata-manger.sh` utility is changing its behaviour so that
`install-packages` *only* installs packages (no container manager).
Update the command to both install Docker and the packages.

Fixes #113.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>