### PR TITLE
rootfs: add '-rm' to delete intermediate container

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -98,6 +98,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 	# In case Clear Containers Runtime is installed we dont want to hit issue:
 	#https://github.com/clearcontainers/runtime/issues/828
 	docker run  \
+		--rm \
 		--runtime runc  \
 		--privileged \
 		--env IMG_SIZE="${IMG_SIZE}" \

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -212,6 +212,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 	# In case Clear Containers Runtime is installed we dont want to hit issue:
 	#https://github.com/clearcontainers/runtime/issues/828
 	docker run  \
+		--rm \
 		--runtime runc  \
 		--env https_proxy="${https_proxy}" \
 		--env http_proxy="${http_proxy}" \


### PR DESCRIPTION
If we set env USE_DOCKER true, we will use container to create rootfs.After docker run command, this temporary container would be no use. we could add -rm flag to automatically delete intermediate container.

Fixes: #115

Signed-off-by: Penny Zheng <penny.zheng@arm.com>