### PR TITLE
CI: Fix static-checks script invocation

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -21,7 +21,7 @@ clone_tests_repo()
 run_static_checks()
 {
 	clone_tests_repo
-	bash "$tests_repo_dir/.ci/static-checks.sh"
+	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/osbuilder"
 }
 
 install_bats()


### PR DESCRIPTION
The `static-checks.sh` script now requires the repo as an argument.

Fixes #120.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>