### PR TITLE
builder: support proxy in distros based on yum or dnf

### DIFF
--- a/image-builder/Dockerfile
+++ b/image-builder/Dockerfile
@@ -1,3 +1,10 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 From fedora:latest
+
+RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
 
 RUN dnf install -y qemu-img parted gdisk e2fsprogs

--- a/rootfs-builder/centos/Dockerfile.in
+++ b/rootfs-builder/centos/Dockerfile.in
@@ -5,6 +5,8 @@
 
 From centos:@OS_VERSION@
 
+@SET_PROXY@
+
 RUN yum -y update && yum install -y git make gcc coreutils
 
 # This will install the proper golang to build Kata components

--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -5,6 +5,8 @@
 
 From fedora:27
 
+@SET_PROXY@
+
 RUN dnf -y update && dnf install -y git systemd pkgconfig gcc coreutils
 
 # This will install the proper golang to build Kata components

--- a/rootfs-builder/euleros/Dockerfile.in
+++ b/rootfs-builder/euleros/Dockerfile.in
@@ -5,6 +5,8 @@
 
 FROM euleros:@OS_VERSION@
 
+@SET_PROXY@
+
 RUN yum -y update && yum install -y yum git make gcc coreutils
 
 # This will install the proper golang to build Kata components

--- a/rootfs-builder/fedora/Dockerfile.in
+++ b/rootfs-builder/fedora/Dockerfile.in
@@ -5,6 +5,8 @@
 
 From fedora:@OS_VERSION@
 
+@SET_PROXY@
+
 RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc coreutils
 
 # This will install the proper golang to build Kata components

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -100,6 +100,8 @@ generate_dockerfile()
 			;;
 	esac
 
+	[ -n "$http_proxy" ] && readonly set_proxy="RUN sed -i '$ a proxy="$http_proxy"' /etc/dnf/dnf.conf /etc/yum.conf; true"
+
 	readonly install_go="
 ADD https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${goarch}.tar.gz /tmp
 RUN tar -C /usr/ -xzf /tmp/go${GO_VERSION}.linux-${goarch}.tar.gz
@@ -115,6 +117,7 @@ ENV PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin
 		-e "s|@GO_VERSION@|${GO_VERSION}|g" \
 		-e "s|@OS_VERSION@|${OS_VERSION}|g" \
 		-e "s|@INSTALL_GO@|${install_go//$'\n'/\\n}|g" \
+		-e "s|@SET_PROXY@|${set_proxy}|g" \
 		${dockerfile_template} > Dockerfile
 	popd
 }


### PR DESCRIPTION
proxy server must be specified in configuration file
of the package manager, /etc/yum.conf for yum or
/etc/dnf/dnf.conf for dnf

fixes #123

Signed-off-by: Julio Montes <julio.montes@intel.com>