### PR TITLE
rootfs: docker: Reduce build time by not reinstalling go

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -103,7 +103,7 @@ generate_dockerfile()
 	[ -n "$http_proxy" ] && readonly set_proxy="RUN sed -i '$ a proxy="$http_proxy"' /etc/dnf/dnf.conf /etc/yum.conf; true"
 
 	readonly install_go="
-ADD https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${goarch}.tar.gz /tmp
+RUN cd /tmp ; curl -OL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${goarch}.tar.gz
 RUN tar -C /usr/ -xzf /tmp/go${GO_VERSION}.linux-${goarch}.tar.gz
 ENV GOROOT=/usr/go
 ENV PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin


### PR DESCRIPTION
Using docker we always add the go tarball. But this takes time if build image multiples times.
Use RUN to avoid duplicated steps already done in dockerfile.

Fixes: #125

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>