### PR TITLE
image-builder: require root earlier for better error messages

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -14,6 +14,8 @@ script_dir="$(dirname $(readlink -f $0))"
 lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
 
+[ "$(id -u)" -eq 0 ] || die "$0: must be run as root"
+
 IMAGE="${IMAGE:-kata-containers.img}"
 AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
@@ -131,7 +133,6 @@ fi
 	die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}
 	use AGENT_BIN env variable to change the expected agent binary name"
 OK "Agent installed"
-[ "$(id -u)" -eq 0 ] || die "$0: must be run as root"
 
 ROOTFS_SIZE=$(du -B 1MB -s "${ROOTFS}" | awk '{print $1}')
 BLOCK_SIZE=${BLOCK_SIZE:-4096}


### PR DESCRIPTION
The image_builder.sh script must be run as root.  The following check is
performed before the script checks for root:

  [ "${AGENT_INIT}" == "yes" ] || [ -x "${ROOTFS}/usr/bin/${AGENT_BIN}" ] || \
      die "/usr/bin/${AGENT_BIN} is not installed in ${ROOTFS}
      use AGENT_BIN env variable to change the expected agent binary name"

The -x test is "True if the file is executable by you".  It may evaluate
to true as root and false as non-root, depending on the file
permissions.

The permissions for kata-agent given in the Developer Guide are 0550
(https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#add-a-custom-agent-to-the-image---optional).

Therefore image_builder.sh fails with "/usr/bin/${AGENT_BIN} is not
installed" when run as non-root.  This is confusing since the agent
binary is really installed!

Move the root check to the beginning of the script.  This solves the
confusing error and prevents similar problems where the script doesn't
take into account that the user may be non-root.

Fixes: #127
Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>