### PR TITLE
initrd-builder: make initrd_builder.sh idempotent

### DIFF
--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -73,7 +73,7 @@ OK "Agent is installed"
 [ "$(id -u)" -eq 0 ] || die "$0: must be run as root"
 
 # initramfs expects /init
-mv -f ${init} "${ROOTFS}/init"
+ln -sf /sbin/init "${ROOTFS}/init"
 
 info "Creating ${IMAGE_DIR}/${IMAGE_NAME} based on rootfs at ${ROOTFS}"
 ( cd "${ROOTFS}" && find . | cpio -H newc -o | gzip -9 ) > "${IMAGE_DIR}"/"${IMAGE_NAME}"


### PR DESCRIPTION
If initrd_builder.sh fails partway through it may not be possible to run
it again without creating a new rootfs.

This happens because initrd_builder.sh checks for the presence of
/sbin/init and refuses to run if it is missing.  Later on, the script
moves /sbin/init to /init, where the kernel expects to find it in an
initramfs.  After this step initrd_builder.sh will refuse to run again
since /sbin/init is now missing.

Create a symlink from /init to /sbin/init instead of moving the file.
This allows initrd_builder.sh to be run repeatedly on the same rootfs.

Fixes: #130
Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>