### PR TITLE
rootfs-fedora: bump Fedora release to 28

### DIFF
--- a/rootfs-builder/fedora/Dockerfile.in
+++ b/rootfs-builder/fedora/Dockerfile.in
@@ -7,7 +7,7 @@ From fedora:@OS_VERSION@
 
 @SET_PROXY@
 
-RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc coreutils
+RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc make
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Fedora"
 
-OS_VERSION=${OS_VERSION:-27}
+OS_VERSION=${OS_VERSION:-28}
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"
 


### PR DESCRIPTION
Fedora 28 was released May 1st 2018.  I have tested that the rootfs
works.

Fixes: #132
Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>