### PR TITLE
CI: Install make on Ubuntu

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -10,8 +10,6 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-bash "${cidir}/static-checks.sh"
-
 #Note: If add clearlinux as supported CI use a stateless os-release file
 source /etc/os-release
 
@@ -22,8 +20,10 @@ elif [ "$ID" == centos ];then
 	sudo -E yum -y install automake yamllint coreutils moreutils
 elif [ "$ID" == ubuntu ];then
 	sudo apt-get -qq update
-	sudo apt-get install -y -qq automake qemu-utils python-pip coreutils moreutils
+	sudo apt-get install -y -qq make automake qemu-utils python-pip coreutils moreutils
 	sudo pip install yamllint
 else 
 	echo "Linux distribution not supported"
 fi
+
+bash "${cidir}/static-checks.sh"


### PR DESCRIPTION
Fix CI build failures on Ubuntu 16.04 due to `make` not being installed.

Fixes #134.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>