### PR TITLE
rootfs: Add script for Debian base OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For further details, see [the tests documentation](tests/README.md).
 
 ## Platform-Distro Compatibility Matrix
 
-| | Alpine | CentOS | ClearLinux | EulerOS | Fedora | 
+| | Alpine | CentOS | ClearLinux | EulerOS | Fedora | Debian |
   |--|--|--|--|--|--|
   | **ARM64** | :heavy_check_mark: | :heavy_check_mark: |  | :heavy_check_mark: | :heavy_check_mark: | 
   | **PPC64le** | :heavy_check_mark: | :heavy_check_mark: |  |  | :heavy_check_mark: | 

--- a/rootfs-builder/debian/Dockerfile.in
+++ b/rootfs-builder/debian/Dockerfile.in
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2018 Luis Chamberlain <mcgrof@kernel.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+From debian:@OS_VERSION@
+
+@SET_PROXY@
+
+RUN apt-get update && apt-get install -y git systemd pkg-config gcc coreutils
+
+# This will install the proper golang to build Kata components
+@INSTALL_GO@

--- a/rootfs-builder/debian/config.sh
+++ b/rootfs-builder/debian/config.sh
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Luis Chamberlain <mcgrof@kernel.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+OS_NAME="Debian"
+
+OS_VERSION=${OS_VERSION:-testing}
+
+# If set, we'll use this to do the debootstrap. The sources.list
+# file however will get MIRROR_LIST. If you want to use the local
+# mirror for both set both to the same value. To set up a local
+# mirror look at apt-move.
+LOCAL_FILE_MIRROR=""
+MIRROR_LIST="http://mirrors.edge.kernel.org/debian/"
+
+PACKAGES="iptables"

--- a/rootfs-builder/debian/rootfs_lib.sh
+++ b/rootfs-builder/debian/rootfs_lib.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Luis Chamberlain <mcgrof@kernel.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# - Arguments
+# rootfs_dir=$1
+#
+# - Optional environment variables
+#
+# EXTRA_PKGS: Variable to add extra PKGS provided by the user
+#
+# BIN_AGENT: Name of the Kata-Agent binary
+#
+# Any other configuration variable for a specific distro must be added
+# and documented on its own config.sh
+#
+# - Expected result
+#
+# rootfs_dir populated with rootfs pkgs
+# It must provide a binary in /sbin/init
+build_rootfs() {
+	# Mandatory
+	local ROOTFS_DIR=$1
+
+	# In case of support EXTRA packages, use it to allow
+	# users add more packages to the base rootfs
+	local EXTRA_PKGS=${EXTRA_PKGS:-}
+
+	# Populate ROOTFS_DIR
+	check_root
+	mkdir -p "${ROOTFS_DIR}"
+	ADD_PKGS=""
+	for i in ${EXTRA_PKGS} ; do
+		if [ "$ADD_PKGS" = "" ]; then
+			ADD_PKGS="$i"
+		else
+			ADD_PKGS="$ADD_PKGS,$i"
+		fi
+	done
+	INCLUDE_EXTRA=""
+	if [ "$ADD_PKGS" = "" ]; then
+		INCLUDE_EXTRA="--include=$ADD_PKGS"
+	fi
+
+	DEBOOTSTRAP_MIRROR="$MIRROR_LIST"
+	if [ "$LOCAL_FILE_MIRROR" != "" ]; then
+		DEBOOTSTRAP_MIRROR="$LOCAL_FILE_MIRROR"
+	fi
+
+	/usr/sbin/debootstrap \
+		$INCLUDE_EXTRA \
+		${OS_VERSION} \
+		$ROOTFS_DIR \
+		$DEBOOTSTRAP_MIRROR
+
+	mkdir -p ${ROOTFS_DIR}{/root,/etc/apt,/proc}
+	echo "deb ${MIRROR}/${OS_VERSION} $OS_VERSION main contrib" >  ${ROOTFS_DIR}/etc/apt/sources.list
+}


### PR DESCRIPTION
Add scripts to build a rootfs based on Debian.

Signed-off-by: Luis Chamberlain <mcgrof@kernel.org>