### PR TITLE
rootfs: Include libseccomp support in rootfs

### DIFF
--- a/rootfs-builder/alpine/Dockerfile.in
+++ b/rootfs-builder/alpine/Dockerfile.in
@@ -6,5 +6,5 @@
 From golang:@GO_VERSION@-alpine3.7
 
 # The "coreutils" package on alpine for reasons unknown does not provide arch(1), so simulate it.
-RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static && \
+RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static libseccomp libseccomp-dev && \
     echo -e '#!/bin/sh\nuname -m' > /usr/bin/arch && chmod +x /usr/bin/arch

--- a/rootfs-builder/centos/Dockerfile.in
+++ b/rootfs-builder/centos/Dockerfile.in
@@ -7,7 +7,7 @@ From centos:@OS_VERSION@
 
 @SET_PROXY@
 
-RUN yum -y update && yum install -y git make gcc coreutils
+RUN yum -y update && yum install -y git make gcc coreutils libseccomp libseccomp-devel
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -7,7 +7,7 @@ From fedora:27
 
 @SET_PROXY@
 
-RUN dnf -y update && dnf install -y git systemd pkgconfig gcc coreutils
+RUN dnf -y update && dnf install -y git systemd pkgconfig gcc coreutils libseccomp libseccomp-devel
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/fedora/Dockerfile.in
+++ b/rootfs-builder/fedora/Dockerfile.in
@@ -7,7 +7,7 @@ From fedora:@OS_VERSION@
 
 @SET_PROXY@
 
-RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc make
+RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc make libseccomp libseccomp-devel
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@


### PR DESCRIPTION
Ensure the image used on the guest does include libseccomp,
otherwise when a seccomp profile is passed by the runtime, it
will end up with boot failure on the guest.

Fixes: #153

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com