### PR TITLE
rootfs: Conditionally add libseccomp support in rootfs image

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -12,4 +12,4 @@ export GOPATH="${GOPATH:-/tmp/go}"
 
 script_dir="$(dirname $(readlink -f $0))"
 
-sudo -E PATH="$PATH" bash "${script_dir}/../tests/test_images.sh"
+sudo -E PATH="$PATH" bash -x "${script_dir}/../tests/test_images.sh"

--- a/rootfs-builder/alpine/config.sh
+++ b/rootfs-builder/alpine/config.sh
@@ -22,3 +22,5 @@ INIT_PROCESS=kata-agent
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true

--- a/rootfs-builder/centos/config.sh
+++ b/rootfs-builder/centos/config.sh
@@ -34,3 +34,5 @@ INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true

--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -27,3 +27,5 @@ INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=(ppc64le)
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true

--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -25,3 +25,5 @@ ARCH_EXCLUDE_LIST=()
 # Allow the build to fail without generating an error.
 # For more info see: https://github.com/kata-containers/osbuilder/issues/190
 BUILD_CAN_FAIL=1
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -19,3 +19,5 @@ PACKAGES="iptables"
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -326,6 +326,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 		--env EXTRA_PKGS="${EXTRA_PKGS}" \
 		--env OSBUILDER_VERSION="${OSBUILDER_VERSION}" \
 		--env INSIDE_CONTAINER=1 \
+		--env SECCOMP="${SECCOMP}" \
 		-v "${script_dir}":"/osbuilder" \
 		-v "${ROOTFS_DIR}":"/rootfs" \
 		-v "${script_dir}/../scripts":"/scripts" \
@@ -352,7 +353,7 @@ pushd "${GOPATH_LOCAL}/src/${GO_AGENT_PKG}"
 [ -n "${AGENT_VERSION}" ] && git checkout "${AGENT_VERSION}" && OK "git checkout successful"
 make clean
 make INIT=${AGENT_INIT}
-make install DESTDIR="${ROOTFS_DIR}" INIT=${AGENT_INIT}
+make install DESTDIR="${ROOTFS_DIR}" INIT=${AGENT_INIT} SECCOMP=${SECCOMP}
 popd
 
 AGENT_DIR="${ROOTFS_DIR}/usr/bin"

--- a/rootfs-builder/ubuntu/config.sh
+++ b/rootfs-builder/ubuntu/config.sh
@@ -28,3 +28,5 @@ INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2" || true


### PR DESCRIPTION
If the rootfs is built with SECCOMP=yes environment
variable then include libseccomp package inside the
rootfs image. Else do not include it.

Fixes: #155

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com