### PR TITLE
Makefile: update targets to better track build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@
 MK_DIR :=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 DISTRO ?= centos
-DISTRO_ROOTFS := "$(PWD)/$(DISTRO)_rootfs"
+DISTRO_ROOTFS := $(PWD)/$(DISTRO)_rootfs
+DISTRO_ROOTFS_MARKER := .$(shell basename $(DISTRO_ROOTFS)).done
+IMAGE := kata-containers.img
+INITRD_IMAGE := kata-containers-initrd.img
 IMG_SIZE=500
 AGENT_INIT ?= no
 
@@ -16,28 +19,43 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
 VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
-all: rootfs image initrd
-rootfs:
+.PHONY: all
+all: image initrd
+
+.PHONY: rootfs
+rootfs: $(DISTRO_ROOTFS_MARKER)
+
+$(DISTRO_ROOTFS_MARKER):
 	@echo Creating rootfs based on "$(DISTRO)"
-	"$(MK_DIR)/rootfs-builder/rootfs.sh" -o $(VERSION_COMMIT) -r "$(DISTRO_ROOTFS)" "$(DISTRO)"
+	"$(MK_DIR)/rootfs-builder/rootfs.sh" -o $(VERSION_COMMIT) -r $(DISTRO_ROOTFS) $(DISTRO)
+	touch $@
 
-image: rootfs image-only
+.PHONY: image
+image: $(IMAGE)
 
-image-only:
+$(IMAGE): rootfs
 	@echo Creating image based on "$(DISTRO_ROOTFS)"
 	"$(MK_DIR)/image-builder/image_builder.sh" -s "$(IMG_SIZE)" "$(DISTRO_ROOTFS)"
 
-initrd: rootfs initrd-only
+.PHONY: initrd
+initrd: $(INITRD_IMAGE)
 
-initrd-only:
+$(INITRD_IMAGE): rootfs
 	@echo Creating initrd image based on "$(DISTRO_ROOTFS)"
 	"$(MK_DIR)/initrd-builder/initrd_builder.sh" "$(DISTRO_ROOTFS)"
 
+.PHONY: test
 test:
 	"$(MK_DIR)/tests/test_images.sh" "$(DISTRO)"
 
+.PHONY: test-image-only
 test-image-only:
 	"$(MK_DIR)/tests/test_images.sh" --test-images-only "$(DISTRO)"
 
+.PHONY: test-initrd-only
 test-initrd-only:
 	"$(MK_DIR)/tests/test_images.sh" --test-initrds-only "$(DISTRO)"
+
+.PHONY: clean
+clean:
+	rm -rf $(DISTRO_ROOTFS_MARKER) $(DISTRO_ROOTFS) $(IMAGE) $(INITRD_IMAGE)

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ further details, see
 #### Image with systemd as init
 
 ```
-$ sudo -E PATH=$PATH make USE_DOCKER=true image-only
+$ sudo -E PATH=$PATH make USE_DOCKER=true image
 ```
 
 #### Image with the agent as init
 
 ```
-$ sudo -E PATH=$PATH make USE_DOCKER=true AGENT_INIT=yes image-only
+$ sudo -E PATH=$PATH make USE_DOCKER=true AGENT_INIT=yes image
 ```
 
 ### Initrd creation
@@ -104,7 +104,7 @@ $ sudo -E PATH=$PATH make USE_DOCKER=true AGENT_INIT=yes image-only
 To create an initrd from the already-created rootfs with the agent acting as the init daemon:
 
 ```
-$ sudo -E PATH=$PATH make AGENT_INIT=yes initrd-only
+$ sudo -E PATH=$PATH make AGENT_INIT=yes initrd
 ```
 
 For further details,


### PR DESCRIPTION
Update Makefile so that build artifacts are actually tracked as make targets. This is to enforce a strict prerequisite ordering and better handle parallel builds.

Fixes: #157

