### PR TITLE
Reformat usage output in test_image.sh

### DIFF
--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Intel Corporation
 #
@@ -36,27 +36,21 @@ test_initrds_only="false"
 usage()
 {
 	cat <<EOT
-Usage: $script_name [help|<distro>]
-       $script_name [options]
+Usage: $script_name [options] [command | <distro>]
 
 Options:
-
   -h | --help          # Show usage.
   --distro <distro>    # Only run tests for specified distro.
   --list               # List all distros that can be tested.
   --test-images-only   # Only run images tests for the list of distros under test.
   --test-initrds-only  # Only run initrds tests for the list of distros under test.
 
-Parameters:
-
-
+Commands:
 help     : Show usage.
-<distro> : Only run tests for specified distro.
 
-Notes:
 
-- If no options or parameters are specified, all tests will be run.
-
+When <distro> is specified, tests are run only for the specified <distro> distribution.
+Otherwise, tests are be run on all distros.
 EOT
 }
 
@@ -98,8 +92,6 @@ exit_handler()
 	info "processes:"
 	sudo -E ps -efwww | egrep "docker|kata" >&2
 }
-
-trap exit_handler EXIT ERR
 
 die()
 {
@@ -504,10 +496,12 @@ main()
 	[ "$1" = "--" ] && shift
 
 	case "$1" in
-		help) usage && exit 0;;
+		help) usage; exit 0;;
+
 		*) distro="$1";;
 	esac
 
+	trap exit_handler EXIT ERR
 	setup
 
 	if [ -n "$distro" ]


### PR DESCRIPTION
Reformat the usage output displayed with `help` command or `-h` option.
Trap exit codes only after options parsing, as that is used to generate a test report.

Before:
```
Usage: test_images.sh [help|<distro>]                                                                                  
       test_images.sh [options]                                                                                        
                                                                                                                       
Options:                                                                                                               
                                                                                                                       
  -h | --help          # Show usage.                                                                                   
  --distro <distro>    # Only run tests for specified distro.                                                          
  --list               # List all distros that can be tested.                                                          
  --test-images-only   # Only run images tests for the list of distros under test.                                     
  --test-initrds-only  # Only run initrds tests for the list of distros under test.                                    
                                                                                                                       
Parameters:                                                                                                            
                                                                                                                       
                                                                                                                       
help     : Show usage.                                                                                                 
<distro> : Only run tests for specified distro.

Notes:

- If no options or parameters are specified, all tests will be run.                                                   

INFO: tests passed successfully - cleaning up
```

After:
```
Usage: test_images.sh [options] [command | <distro>]

Options:
  -h | --help          # Show usage.
  --distro <distro>    # Only run tests for specified distro.                                                         
  --list               # List all distros that can be tested.                                                         
  --test-images-only   # Only run images tests for the list of distros under test.                                    
  --test-initrds-only  # Only run initrds tests for the list of distros under test.                                   

Commands:
help     : Show usage.


When <distro> is specified, tests are run only for the specified <distro> distribution.                               
Otherwise, tests are be run on all distros.
```