### PR TITLE
tests: parallel images build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ os:
 
 language: bash
 
-env:
-  - AGENT_INIT=no
-  - AGENT_INIT=yes
-
 services:
   - docker
 

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -52,8 +52,8 @@ $(get_distros)
 Refer the Platform-OS Compatibility Matrix: https://github.com/kata-containers/osbuilder#platform-distro-compatibility-matrix
 
 Options:
--a  : agent version DEFAULT: ${AGENT_VERSION} ENV: AGENT_VERSION 
--h  : Show this help message
+-a  : agent version DEFAULT: ${AGENT_VERSION} ENV: AGENT_VERSION
+-h  : show this help message
 -o  : specify version of osbuilder
 -r  : rootfs directory DEFAULT: ${ROOTFS_DIR} ENV: ROOTFS_DIR
 
@@ -90,7 +90,7 @@ distro_needs_admin_caps()
 		then
 			echo "true"
 		elif [ "$1" = "debian" ]
-		then 
+		then
 			echo "true"
 		else
 			echo "false"

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 SUSE LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+distrosSystemd=(fedora centos ubuntu debian)
+distrosAgent=(alpine)
+
+if [ $MACHINE_TYPE != "ppc64le" ]; then
+	distrosSystemd+=(clearlinux)
+fi
+
+# "Not testing eurleros on Travis: (timeout, see: https://github.com/kata-containers/osbuilder/issues/46)"
+if [ -z "${TRAVIS:-}" ]; then
+	distrosSystemd+=(euleros)
+fi
+


### PR DESCRIPTION
Rework test_image.sh and Makefile to allow building images in parallel
for faster test execution.
Add some new targets to Makefile ({rootfs,image,initrd}-all,
list-distros).

Fixes: #168