### PR TITLE
builder: create init symlink to /sbin/init

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -301,6 +301,7 @@ AGENT_DEST="${AGENT_DIR}/${AGENT_BIN}"
 OK "Agent installed"
 
 [ "${AGENT_INIT}" == "yes" ] && setup_agent_init "${AGENT_DEST}" "${init}"
+ln -sf /sbin/init "${ROOTFS_DIR}/init"
 
 info "Check init is installed"
 [ -x "${init}" ] || [ -L "${init}" ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"


### PR DESCRIPTION
`/sbin/init` always points to the init process that can be
kata-agent or systemd.
Creating a symlink to `/sbin/init` makes life easier to the
kata-runtime since it doesn't need to know who is the init process
and the kernel command line `init` can be removed.

Signed-off-by: Julio Montes <julio.montes@intel.com>