### PR TITLE
tests: Sort size summary by image size and rootfs size

### DIFF
--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -120,7 +120,7 @@ show_stats()
 		"Type" \
 		"Name"
 
-	sort -k1,1n "$tmpfile"
+	sort -k1,1n -k3,3n "$tmpfile"
 
 	rm -f "${tmpfile}"
 }


### PR DESCRIPTION
Sort the table of image sizes by rootfs size after having sorted by image size so that the smaller rootfs images appear before larger ones when the image size is the same.

Fixes #178.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>