### PR TITLE
Fix link in README

### DIFF
--- a/image-builder/README.md
+++ b/image-builder/README.md
@@ -17,7 +17,7 @@ $ sudo ./image_builder.sh path/to/rootfs
 Where `path/to/rootfs` is the directory populated by `rootfs.sh`.
 
 > **Note**: If you are building an image from an Alpine rootfs, see
-> the important note [here](rootfs-builder/README.md#rootfs-requirements).
+> the important note [here](/rootfs-builder/README.md#rootfs-requirements).
 
 ## Further information
 


### PR DESCRIPTION
Link to rootfs requirements section of rootfs-builder README page was missing a '/' in the link