### PR TITLE
tests: get config from distro-specific config.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ test-image-only:
 test-initrd-only:
 	$(TEST_RUNNER) --test-initrds-only "$(DISTRO)"
 
+.PHONY: list-distros
+list-distros:
+	@ $(ROOTFS_BUILDER) -l
+
 .PHONY: clean
 clean:
 	rm -rf $(DISTRO_ROOTFS_MARKER) $(DISTRO_ROOTFS) $(DISTRO_IMAGE) $(DISTRO_INITRD)

--- a/rootfs-builder/alpine/config.sh
+++ b/rootfs-builder/alpine/config.sh
@@ -16,3 +16,9 @@ MIRROR=http://dl-5.alpinelinux.org/alpine
 # Mandatory Packages that must be installed
 #  - iptables: Need by Kata agent
 PACKAGES="iptables"
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=kata-agent
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()

--- a/rootfs-builder/centos/config.sh
+++ b/rootfs-builder/centos/config.sh
@@ -28,3 +28,9 @@ PACKAGES="iptables"
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
 [ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()

--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -21,3 +21,9 @@ PACKAGES="iptables-bin libudev0-shim"
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
 [ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=(ppc64le)

--- a/rootfs-builder/debian/config.sh
+++ b/rootfs-builder/debian/config.sh
@@ -10,3 +10,9 @@ OS_NAME=${OS_NAME:-"stretch"}
 
 # NOTE: Re-using ubuntu rootfs configuration, see 'ubuntu' folder for full content.
 source $script_dir/ubuntu/$CONFIG_SH
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()

--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2018 Huawei Technologies Co., Ltd
+#
+# SPDX-License-Identifier: Apache-2.0
 OS_NAME="EulerOS"
 
 OS_VERSION=${OS_VERSION:-2.2}
@@ -12,3 +16,9 @@ PACKAGES="iptables"
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
 [ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -15,3 +15,7 @@ PACKAGES="iptables"
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
 [ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+ARCH_EXCLUDE_LIST=()

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -54,8 +54,10 @@ Refer the Platform-OS Compatibility Matrix: https://github.com/kata-containers/o
 Options:
 -a  : agent version DEFAULT: ${AGENT_VERSION} ENV: AGENT_VERSION
 -h  : show this help message
+-l  : list the supported Linux distributions
 -o  : specify version of osbuilder
 -r  : rootfs directory DEFAULT: ${ROOTFS_DIR} ENV: ROOTFS_DIR
+-t  : print the test config for a given <distro_name>
 
 ENV VARIABLES:
 GO_AGENT_PKG: Change the golang package url to get the agent source code
@@ -76,6 +78,15 @@ get_distros() {
 	find ${cdirs} -maxdepth 1 -name "${CONFIG_SH}" -printf '%H\n' | while read dir; do
 		basename "${dir}"
 	done
+}
+
+get_test_config() {
+	local distro="$1"
+	local config="${script_dir}/${distro}/config.sh"
+	source ${config}
+
+	echo -e "INIT_PROCESS:\t\t$INIT_PROCESS"
+	echo -e "ARCH_EXCLUDE_LIST:\t\t${ARCH_EXCLUDE_LIST[@]}"
 }
 
 check_function_exist()
@@ -180,13 +191,15 @@ copy_kernel_modules()
 
 OSBUILDER_VERSION="unknown"
 
-while getopts a:ho:r: opt
+while getopts a:hlo:r:t: opt
 do
 	case $opt in
 		a)	AGENT_VERSION="${OPTARG}" ;;
 		h)	usage ;;
+		l)	get_distros | sort && exit 0;;
 		o)	OSBUILDER_VERSION="${OPTARG}" ;;
 		r)	ROOTFS_DIR="${OPTARG}" ;;
+		t)	get_test_config "${OPTARG}" && exit 0;;
 	esac
 done
 

--- a/rootfs-builder/suse/config.sh
+++ b/rootfs-builder/suse/config.sh
@@ -20,9 +20,16 @@ REPO_TRANSPORT="https"
 # Can specify an alternative domain
 REPO_DOMAIN="download.opensuse.org"
 
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()
+
+###############################################################################
+#
 # NOTE: you probably dont need to edit things below this
 #
-###############################################################################
 
 SUSE_URL_BASE="${REPO_TRANSPORT}://${REPO_DOMAIN}"
 SUSE_PATH_OSS="/distribution/${OS_DISTRO,,}/$OS_VERSION/repo/oss"

--- a/rootfs-builder/template/config_template.sh
+++ b/rootfs-builder/template/config_template.sh
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This is a configuration file add extra variables to
 # be used by build_rootfs() from rootfs_lib.sh the variables will be
 # loaded just before call the function. For more information see the
@@ -6,3 +11,9 @@
 OS_VERSION=${OS_VERSION:-DEFAULT_VERSION}
 
 PACKAGES="systemd iptables udevlib.so"
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()

--- a/rootfs-builder/ubuntu/config.sh
+++ b/rootfs-builder/ubuntu/config.sh
@@ -22,3 +22,9 @@ case $(arch) in
 	aarch64) ARCHITECTURE="arm64";;
 	(*) die "$(arch) not supported "
 esac
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -3,15 +3,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-distrosSystemd=(fedora centos ubuntu debian suse)
-distrosAgent=(alpine)
 
-if [ $MACHINE_TYPE != "ppc64le" ]; then
-	distrosSystemd+=(clearlinux)
+if [ -n "${CI:-}" ]; then
+	# "Not testing eurleros on Jenkins or Travis:
+	# (unreliable mirros, see: https://github.com/kata-containers/osbuilder/issues/182)
+	# (timeout, see: https://github.com/kata-containers/osbuilder/issues/46)"
+	skipWhenTestingAll=(euleros)
 fi
 
-# "Not testing eurleros on Travis: (timeout, see: https://github.com/kata-containers/osbuilder/issues/46)"
-if [ -z "${TRAVIS:-}" ]; then
-	distrosSystemd+=(euleros)
+if [ -n "${TRAVIS:-}" ]; then
+	skipWhenTestingAll+=()
 fi
 


### PR DESCRIPTION
Move the test configuration in the distro-specific config.sh
file, for better control of what to include/exclude from
testing based on the test environment.
test_config.sh is still used to exclude specific distros from
being tested, when running tests in bulk.
    
Fixes: #182