### PR TITLE
tests: allow rootfs build to fail for specific distros

### DIFF
--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -22,3 +22,6 @@ INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
+# Allow the build to fail without generating an error.
+# For more info see: https://github.com/kata-containers/osbuilder/issues/190
+BUILD_CAN_FAIL=1

--- a/rootfs-builder/template/config_template.sh
+++ b/rootfs-builder/template/config_template.sh
@@ -17,3 +17,6 @@ INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
+# [When uncommented,] Allow the build to fail without generating an error
+# For more info see: https://github.com/kata-containers/osbuilder/issues/190
+#BUILD_CAN_FAIL=1

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -3,15 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-if [ -n "${CI:-}" ]; then
-	# "Not testing eurleros on Jenkins or Travis:
-	# (unreliable mirros, see: https://github.com/kata-containers/osbuilder/issues/182)
-	# (timeout, see: https://github.com/kata-containers/osbuilder/issues/46)"
-	skipWhenTestingAll=(euleros)
-fi
+# List of distros not to test, when running all tests with test_images.sh
+typeset -a skipWhenTestingAll
 
 if [ -n "${TRAVIS:-}" ]; then
-	skipWhenTestingAll+=()
+	# (travis may timeout with euleros, see:
+	#  https://github.com/kata-containers/osbuilder/issues/46)"
+	skipWhenTestingAll+=(euleros)
 fi
 


### PR DESCRIPTION
When running test_images.sh, allow specific rootfs builds to
fail without impacting the overall tests results.
The distros allowed to fail are the ones specifying
BUILD_CAN_FAIL in their config.sh.
