### PR TITLE
rootfs.sh: enable curl use http_proxy

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -140,8 +140,10 @@ generate_dockerfile()
 
 	[ -n "$http_proxy" ] && readonly set_proxy="RUN sed -i '$ a proxy="$http_proxy"' /etc/dnf/dnf.conf /etc/yum.conf; true"
 
+	curlOptions=("-OL")
+	[ -n "$http_proxy" ] && curlOptions+=("-x $http_proxy")
 	readonly install_go="
-RUN cd /tmp ; curl -OL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${goarch}.tar.gz
+RUN cd /tmp ; curl ${curlOptions[@]} https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${goarch}.tar.gz
 RUN tar -C /usr/ -xzf /tmp/go${GO_VERSION}.linux-${goarch}.tar.gz
 ENV GOROOT=/usr/go
 ENV PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin


### PR DESCRIPTION
This patch added -x option to curl: -x uses the http_proxy
settings to download golang binary behind the firewall

Signed-off-by: Leno Hou <lenohou@gmail.com>