### PR TITLE
rootfs: Support agent tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ INITRD_BUILDER := $(MK_DIR)/initrd-builder/initrd_builder.sh
 IMAGE_BUILDER  := $(MK_DIR)/image-builder/image_builder.sh
 
 AGENT_INIT            ?= no
+AGENT_TRACE           ?= no
 DISTRO                ?= centos
 ROOTFS_BUILD_DEST     := $(PWD)
 IMAGES_BUILD_DEST     := $(PWD)

--- a/rootfs-builder/README.md
+++ b/rootfs-builder/README.md
@@ -52,6 +52,20 @@ To build a rootfs for your chosen distribution, run:
 $ sudo ./rootfs.sh <distro>
 ```
 
+### Enabling tracing
+
+To build a rootfs with agent tracing support, specify the `AGENT_TRACE=yes`
+option:
+
+```
+$ sudo AGENT_TRACE="yes" AGENT_INIT="no" ./rootfs.sh <distro>
+```
+
+> **NOTE:**:
+>
+> Tracing only works for non-initrd images.
+> See https://github.com/kata-containers/agent/blob/master/TRACING.md for further details.
+
 ## Creating a rootfs with kernel modules
 
 To build a rootfs with additional kernel modules, run:

--- a/rootfs-builder/alpine/config.sh
+++ b/rootfs-builder/alpine/config.sh
@@ -24,6 +24,7 @@ INIT_PROCESS=kata-agent
 ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/alpine/config.sh
+++ b/rootfs-builder/alpine/config.sh
@@ -23,4 +23,7 @@ INIT_PROCESS=kata-agent
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
 
-[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/centos/config.sh
+++ b/rootfs-builder/centos/config.sh
@@ -36,6 +36,7 @@ INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/centos/config.sh
+++ b/rootfs-builder/centos/config.sh
@@ -27,7 +27,7 @@ PACKAGES="iptables chrony"
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd"
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd
@@ -35,4 +35,7 @@ INIT_PROCESS=systemd
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
 
-[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -29,6 +29,7 @@ INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=(ppc64le)
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -20,7 +20,7 @@ PACKAGES="iptables-bin libudev0-shim chrony"
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd"
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd
@@ -28,4 +28,7 @@ INIT_PROCESS=systemd
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=(ppc64le)
 
-[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/debian/config.sh
+++ b/rootfs-builder/debian/config.sh
@@ -20,6 +20,7 @@ INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/debian/config.sh
+++ b/rootfs-builder/debian/config.sh
@@ -18,3 +18,8 @@ INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2"
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -27,6 +27,7 @@ ARCH_EXCLUDE_LIST=()
 BUILD_CAN_FAIL=1
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -15,7 +15,7 @@ PACKAGES="iptables chrony"
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd"
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd
@@ -26,4 +26,7 @@ ARCH_EXCLUDE_LIST=()
 # For more info see: https://github.com/kata-containers/osbuilder/issues/190
 BUILD_CAN_FAIL=1
 
-[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -14,10 +14,13 @@ PACKAGES="iptables chrony"
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd"
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
 
-[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -21,6 +21,7 @@ INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/suse/config.sh
+++ b/rootfs-builder/suse/config.sh
@@ -56,3 +56,8 @@ SUSE_FULLURL_UPDATE="${SUSE_URL_BASE}${SUSE_PATH_UPDATE}"
 if [ -z "${REPO_URL:-}" ]; then
 	REPO_URL="$SUSE_FULLURL_OSS"
 fi
+
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2"
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/suse/config.sh
+++ b/rootfs-builder/suse/config.sh
@@ -58,6 +58,7 @@ if [ -z "${REPO_URL:-}" ]; then
 fi
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/template/config_template.sh
+++ b/rootfs-builder/template/config_template.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,3 +20,6 @@ ARCH_EXCLUDE_LIST=()
 # [When uncommented,] Allow the build to fail without generating an error
 # For more info see: https://github.com/kata-containers/osbuilder/issues/190
 #BUILD_CAN_FAIL=1
+
+# Ensure script succeeds when sourced
+true

--- a/rootfs-builder/ubuntu/config.sh
+++ b/rootfs-builder/ubuntu/config.sh
@@ -31,6 +31,7 @@ INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2"
+[ "$AGENT_TRACE" = "yes" ] && PACKAGES+=" socat"
 
 # Ensure script succeeds when sourced
 true

--- a/rootfs-builder/ubuntu/config.sh
+++ b/rootfs-builder/ubuntu/config.sh
@@ -30,4 +30,7 @@ INIT_PROCESS=systemd
 # as reported by  `uname -m`
 ARCH_EXCLUDE_LIST=()
 
-[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2" || true
+[ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2"
+
+# Ensure script succeeds when sourced
+true


### PR DESCRIPTION
Add `AGENT_TRACE=yes` option to build a rootfs with agent tracing support.

Fixes #199.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>