### PR TITLE
tests: skip docker,kata install with KATA_DEV_MODE

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -7,10 +7,10 @@ osbuilder provides a test script that creates all images and initrds for all
 supported distributions and then tests them to ensure a Kata Container can
 be created with each.
 
-The test script installs all required Kata components on the host system
-before creating the images.
-
-To run all available osbuilder tests:
+Before the build phase, the test script installs the Docker container manager
+and all the Kata components required to run test containers. This step can be
+skipped by setting the environment variable `KATA_DEV_MODE` to a non-empty
+value.
 
 ```
 $ ./test_images.sh

--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -153,11 +153,26 @@ exit_handler()
 	info "ERROR: test failed"
 
 	# The test failed so dump what we can
-	info "images:"
-	sudo -E ls -l "${images_dir}" >&2
+	if [ -d "${tmp_rootfs}" ]; then
+		info "rootfs:"
+		sudo -E ls -l "${tmp_rootfs}" >&2
+	else
+		info "no rootfs created"
+		# If no rootfs are created, no need to dump other info
+		return
+	fi
 
-	info "rootfs:"
-	sudo -E ls -l "${tmp_rootfs}" >&2
+	if [ -d "${images_dir}" ]; then
+		info "images:"
+		sudo -E ls -l "${images_dir}" >&2
+	else
+		info "no images created"
+		# If no images are created, no need to dump other info
+		return
+	fi
+
+	# Travis tests do not install kata
+	[ -n "${TRAVIS:-}" ] && return
 
 	info "local runtime config:"
 	cat /etc/kata-containers/configuration.toml >&2
@@ -172,7 +187,7 @@ exit_handler()
 	sudo -E ps -efwww | egrep "docker|kata" >&2
 
 	# Restore the default image in config file
-	[ -n "${TRAVIS:-}" ] || chronic $mgr configure-image
+	chronic $mgr configure-image
 }
 
 die()


### PR DESCRIPTION
Skip installation of docker and kata packages when the environment
variable KATA_DEV_MODE is not empty, as a dev system may be using
a non standard setup.

Fixes: #195
