### PR TITLE
Add 'install' target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,40 @@ test-initrd-only:
 list-distros:
 	@ $(ROOTFS_BUILDER) -l
 
+DESTDIR := /
+KATADIR := /usr/libexec/kata-containers
+OSBUILDER_DIR := $(KATADIR)/osbuilder
+INSTALL_DIR :=$(DESTDIR)/$(OSBUILDER_DIR)
+DIST_CONFIGS:= $(wildcard rootfs-builder/*/config.sh)
+
+SCRIPTS :=
+SCRIPTS += rootfs-builder/rootfs.sh
+SCRIPTS += image-builder/image_builder.sh
+SCRIPTS += initrd-builder/initrd_builder.sh
+
+FILES :=
+FILES += rootfs-builder/versions.txt
+FILES += scripts/lib.sh
+
+define INSTALL_FILE
+	echo "Installing $(abspath $2/$1)";
+	install -m 644 -D $1 $2/$1;
+endef
+
+define INSTALL_SCRIPT
+	echo "Installing $(abspath $2/$1)";
+	install -m 755 -D $1 $(abspath $2/$1);
+endef
+
+.PHONY: install-scripts
+install-scripts:
+	@echo "Installing scripts"
+	@$(foreach f,$(SCRIPTS),$(call INSTALL_SCRIPT,$f,$(INSTALL_DIR)))
+	@echo "Installing helper files"
+	@$(foreach f,$(FILES),$(call INSTALL_FILE,$f,$(INSTALL_DIR)))
+	@echo "Installing installing config files"
+	@$(foreach f,$(DIST_CONFIGS),$(call INSTALL_FILE,$f,$(INSTALL_DIR)))
+
 .PHONY: clean
 clean:
 	rm -rf $(DISTRO_ROOTFS_MARKER) $(DISTRO_ROOTFS) $(DISTRO_IMAGE) $(DISTRO_INITRD)

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -16,6 +16,7 @@ AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
 KERNEL_MODULES_DIR=${KERNEL_MODULES_DIR:-""}
 OSBUILDER_VERSION="unknown"
+export GOPATH=${GOPATH:-${HOME}/go}
 
 lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -78,6 +78,9 @@ AGENT_SOURCE_BIN    Path to the directory of agent binary.
                     If set, use the binary as agent but not build agent package.
                     Default value: <not set>
 
+DISTRO_REPO         Use host repositories to install guest packages.
+                    Default value: <not set>
+
 GO_AGENT_PKG        URL of the Git repository hosting the agent package.
                     Default value: ${GO_AGENT_PKG}
 
@@ -356,6 +359,11 @@ fi
 
 mkdir -p ${ROOTFS_DIR}
 build_rootfs ${ROOTFS_DIR}
+pushd "${ROOTFS_DIR}" >> /dev/null
+if [ "$PWD" != "/" ] ; then
+	rm -rf ./var/cache/dnf/
+fi
+popd  >> /dev/null
 
 [ -n "${KERNEL_MODULES_DIR}" ] && copy_kernel_modules ${KERNEL_MODULES_DIR} ${ROOTFS_DIR}
 


### PR DESCRIPTION
Allow install osbuilder scripts in a host, packages like 
https://bugzilla.redhat.com/show_bug.cgi?id=1590414 may install them in the host.