### PR TITLE
 suse: fix port URL detection for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,6 @@ For further details, see [the tests documentation](tests/README.md).
 
 |           |Alpine            |CentOS            |ClearLinux        |Debian/Ubuntu     |EulerOS           |Fedora            |openSUSE          |
 |--         |--                |--                |--                |--                |--                |--                |--                |
-|**ARM64**  |:heavy_check_mark:|:heavy_check_mark:|                  |                  |:heavy_check_mark:|:heavy_check_mark:|                  |
+|**ARM64**  |:heavy_check_mark:|:heavy_check_mark:|                  |                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |**PPC64le**|:heavy_check_mark:|:heavy_check_mark:|                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |**x86_64** |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|

--- a/rootfs-builder/suse/config.sh
+++ b/rootfs-builder/suse/config.sh
@@ -35,15 +35,19 @@ SUSE_URL_BASE="${REPO_TRANSPORT}://${REPO_DOMAIN}"
 SUSE_PATH_OSS="/distribution/${OS_DISTRO,,}/$OS_VERSION/repo/oss"
 SUSE_PATH_UPDATE="/update/${OS_DISTRO,,}/$OS_VERSION/oss"
 
-case "$(uname -m)" in
+arch="$(uname -m)"
+case "$arch" in
 	x86_64)
 		REPO_URL_PORT=""
 		;;
 	ppc|ppc64le)
 		REPO_URL_PORT="/ports/ppc"
 		;;
+	aarch64)
+		REPO_URL_PORT="/ports/aarch64"
+		;;
 	*)
-		REPO_URL_PORT="/ports/$arch"
+		die "Unsupported architecture: $arch"
 		;;
 esac
 SUSE_FULLURL_OSS="${SUSE_URL_BASE}${REPO_URL_PORT}${SUSE_PATH_OSS}"


### PR DESCRIPTION
Fix port URL detection for aarch64, and error out if an unknown
architecture is detected.

Fixes: #215
