### PR TITLE
setup: Add make and gcc as dependencies

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -14,7 +14,7 @@ source "${cidir}/lib.sh"
 source /etc/os-release
 
 if [ "$ID" == fedora ];then
-	sudo -E dnf -y install automake yamllint coreutils moreutils bc
+	sudo -E dnf -y install automake yamllint coreutils moreutils bc make gcc
 elif [ "$ID" == centos ];then
 	sudo -E yum -y install epel-release
 	sudo -E yum -y install automake yamllint coreutils moreutils bc


### PR DESCRIPTION
We require make and gcc to run our CI tools.

Fixes: #219.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>