### PR TITLE
arch: Remove calls to arch command

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -51,7 +51,7 @@ MAX_IMG_SIZE_MB=2048
 FS_TYPE=${FS_TYPE:-"ext4"}
 
 # In order to support memory hotplug, image must be aligned to memory section(size in MB) according to different architecture.
-ARCH=$(arch)
+ARCH=$(uname -m)
 case "$ARCH" in
 	aarch64)	MEM_BOUNDARY_MB=1024 ;;
 	      *)        MEM_BOUNDARY_MB=128  ;;

--- a/rootfs-builder/alpine/Dockerfile.in
+++ b/rootfs-builder/alpine/Dockerfile.in
@@ -5,6 +5,4 @@
 
 From golang:@GO_VERSION@-alpine3.7
 
-# The "coreutils" package on alpine for reasons unknown does not provide arch(1), so simulate it.
-RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static libseccomp libseccomp-dev && \
-    echo -e '#!/bin/sh\nuname -m' > /usr/bin/arch && chmod +x /usr/bin/arch
+RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static libseccomp libseccomp-dev

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -22,7 +22,7 @@ lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
 
 # Default architecture
-ARCH=$(arch)
+ARCH=$(uname -m)
 
 # Load default versions for golang and other componets
 source "${script_dir}/versions.txt"
@@ -162,7 +162,7 @@ generate_dockerfile()
 {
 	dir="$1"
 
-	case "$(arch)" in
+	case "$(uname -m)" in
 		"ppc64le")
 			goarch=ppc64le
 			;;

--- a/rootfs-builder/ubuntu/config.sh
+++ b/rootfs-builder/ubuntu/config.sh
@@ -16,12 +16,12 @@ PACKAGES="systemd iptables init"
 
 DEBOOTSTRAP=${PACKAGE_MANAGER:-"debootstrap"}
 
-case $(arch) in
+case $(uname -m) in
 	x86_64) ARCHITECTURE="amd64";;
 	ppc64le) ARCHITECTURE="ppc64el";;
 	aarch64) ARCHITECTURE="arm64";;
 	s390x)	ARCHITECTURE="s390x";;
-	(*) die "$(arch) not supported "
+	(*) die "$(uname -m) not supported "
 esac
 
 # Init process must be one of {systemd,kata-agent}


### PR DESCRIPTION
The `arch(1)` command is not available on some systems so use the
`uname(1)` command for the equivalent functionality.

Fixes #150.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>