### PR TITLE
tests: skip euleros

### DIFF
--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -6,9 +6,8 @@
 # List of distros not to test, when running all tests with test_images.sh
 typeset -a skipWhenTestingAll
 
-if [ -n "${TRAVIS:-}" ]; then
-	# (travis may timeout with euleros, see:
-	#  https://github.com/kata-containers/osbuilder/issues/46)"
+if [ -n "${CI:-}" ]; then
+	# CI tests may timeout with euleros, see:
+	#  https://github.com/kata-containers/osbuilder/issues/46"
 	skipWhenTestingAll+=(euleros)
 fi
-

--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -251,6 +251,7 @@ setup()
 	[ ! -d "${tests_repo_dir}" ] && git clone "https://${tests_repo}" "${tests_repo_dir}"
 
 	if [ -z "${KATA_DEV_MODE:-}" ]; then
+		chronic $mgr remove-docker
 		chronic $mgr install-docker-system
 	else
 		info "Running with KATA_DEV_MODE set, skipping installation of docker and kata packages"


### PR DESCRIPTION
euleros mirrors are down almost all time, don't fail if euleros rootfs
or image can't be generated.

fixes #238

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
Signed-off-by: Julio Montes <julio.montes@intel.com>