### PR TITLE
Print attempt number after max check

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -205,10 +205,10 @@ detach()
 create_rootfs_disk()
 {
 	ATTEMPT_NUM=$(($ATTEMPT_NUM+1))
-	info "Create root disk image. Attempt ${ATTEMPT_NUM} out of ${MAX_ATTEMPTS}."
 	if [ ${ATTEMPT_NUM} -gt ${MAX_ATTEMPTS} ]; then
 		die "Unable to create root disk image."
 	fi
+	info "Create root disk image. Attempt ${ATTEMPT_NUM} out of ${MAX_ATTEMPTS}."
 
 	calculate_img_size
 	if [ ${OLD_IMG_SIZE} -ne 0 ]; then


### PR DESCRIPTION
With the old code it was possible to see odd messages like:
"INFO: Create root disk image. Attempt 6 out of 5."

Move the attempt number print to after we check against the max