### PR TITLE
Add chrony to image

### DIFF
--- a/rootfs-builder/centos/Dockerfile.in
+++ b/rootfs-builder/centos/Dockerfile.in
@@ -7,7 +7,7 @@ From centos:@OS_VERSION@
 
 @SET_PROXY@
 
-RUN yum -y update && yum install -y git make gcc coreutils libseccomp libseccomp-devel
+RUN yum -y update && yum install -y git make gcc coreutils libseccomp libseccomp-devel chrony
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/centos/config.sh
+++ b/rootfs-builder/centos/config.sh
@@ -22,7 +22,7 @@ GPG_KEY_URL="https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7"
 
 GPG_KEY_FILE="RPM-GPG-KEY-CentOS-7"
 
-PACKAGES="iptables"
+PACKAGES="iptables chrony"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent

--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -7,7 +7,7 @@ From fedora:27
 
 @SET_PROXY@
 
-RUN dnf -y update && dnf install -y git systemd pkgconfig gcc coreutils libseccomp libseccomp-devel
+RUN dnf -y update && dnf install -y git systemd pkgconfig gcc coreutils libseccomp libseccomp-devel chrony
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -15,7 +15,7 @@ clr_url="https://download.clearlinux.org"
 
 BASE_URL="${clr_url}/releases/${OS_VERSION}/${REPO_NAME}/${ARCH}/os/"
 
-PACKAGES="iptables-bin libudev0-shim"
+PACKAGES="iptables-bin libudev0-shim chrony"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent

--- a/rootfs-builder/debian/Dockerfile.in
+++ b/rootfs-builder/debian/Dockerfile.in
@@ -7,7 +7,7 @@
 from debian:@OS_VERSION@
 
 # RUN commands
-RUN apt-get update && apt-get install -y curl wget systemd debootstrap git build-essential
+RUN apt-get update && apt-get install -y curl wget systemd debootstrap git build-essential chrony
 # This will install the proper golang to build Kata components
 @INSTALL_GO@
 

--- a/rootfs-builder/debian/config.sh
+++ b/rootfs-builder/debian/config.sh
@@ -8,6 +8,8 @@ OS_VERSION=${OS_VERSION:-9.5}
 # Set OS_NAME to the desired debian "codename"
 OS_NAME=${OS_NAME:-"stretch"}
 
+PACKAGES="systemd iptables init chrony"
+
 # NOTE: Re-using ubuntu rootfs configuration, see 'ubuntu' folder for full content.
 source $script_dir/ubuntu/$CONFIG_SH
 

--- a/rootfs-builder/euleros/Dockerfile.in
+++ b/rootfs-builder/euleros/Dockerfile.in
@@ -7,7 +7,7 @@ FROM euleros:@OS_VERSION@
 
 @SET_PROXY@
 
-RUN yum -y update && yum install -y yum git make gcc coreutils
+RUN yum -y update && yum install -y yum git make gcc coreutils chrony
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -10,7 +10,7 @@ BASE_URL="http://developer.huawei.com/ict/site-euleros/euleros/repo/yum/${OS_VER
 
 GPG_KEY_FILE="RPM-GPG-KEY-EulerOS"
 
-PACKAGES="iptables"
+PACKAGES="iptables chrony"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent

--- a/rootfs-builder/fedora/Dockerfile.in
+++ b/rootfs-builder/fedora/Dockerfile.in
@@ -7,7 +7,7 @@ From fedora:@OS_VERSION@
 
 @SET_PROXY@
 
-RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc make libseccomp libseccomp-devel
+RUN dnf -y update && dnf install -y git redhat-release systemd pkgconfig gcc make libseccomp libseccomp-devel chrony
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -9,7 +9,7 @@ OS_VERSION=${OS_VERSION:-28}
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"
 
-PACKAGES="iptables"
+PACKAGES="iptables chrony"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -376,6 +376,10 @@ fi
 info "Configure chrony file ${chrony_conf_file}"
 echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> ${chrony_conf_file}
 
+# Comment out ntp sources for chrony to be extra careful
+# Reference:  https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html
+sed -i 's/^\(server \|pool \|peer \)/# &/g'  ${chrony_conf_file}
+
 # The CC on s390x for fedora needs to be manually set to gcc when the golang is downloaded from the main page.
 # See issue: https://github.com/kata-containers/osbuilder/issues/217
 [ "$distro" == fedora ] && [ "$ARCH" == "s390x" ] && export CC=gcc

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -368,6 +368,14 @@ popd  >> /dev/null
 
 [ -n "${KERNEL_MODULES_DIR}" ] && copy_kernel_modules ${KERNEL_MODULES_DIR} ${ROOTFS_DIR}
 
+chrony_conf_file="${ROOTFS_DIR}/etc/chrony.conf"
+if [ ${distro} == ubuntu ] || [ ${distro} == debian ] ; then
+	chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
+fi 
+
+info "Configure chrony file ${chrony_conf_file}"
+echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> ${chrony_conf_file}
+
 # The CC on s390x for fedora needs to be manually set to gcc when the golang is downloaded from the main page.
 # See issue: https://github.com/kata-containers/osbuilder/issues/217
 [ "$distro" == fedora ] && [ "$ARCH" == "s390x" ] && export CC=gcc

--- a/rootfs-builder/ubuntu/Dockerfile.in
+++ b/rootfs-builder/ubuntu/Dockerfile.in
@@ -11,7 +11,7 @@ from ubuntu:@OS_VERSION@
 # Install any package need to create a rootfs (package manager, extra tools)
 
 # RUN commands
-RUN apt-get update && apt-get install -y curl wget systemd debootstrap git build-essential
+RUN apt-get update && apt-get install -y curl wget systemd debootstrap git build-essential chrony
 # This will install the proper golang to build Kata components
 @INSTALL_GO@
 

--- a/rootfs-builder/ubuntu/config.sh
+++ b/rootfs-builder/ubuntu/config.sh
@@ -12,7 +12,7 @@ OS_VERSION=${OS_VERSION:-18.04}
 OS_NAME=${OS_NAME:-"bionic"}
 
 # packages to be installed by default
-PACKAGES="systemd iptables init"
+PACKAGES="systemd iptables init chrony"
 
 DEBOOTSTRAP=${PACKAGE_MANAGER:-"debootstrap"}
 


### PR DESCRIPTION
chrony will be used to schronize guest clock with host
using kvm_ptp kernel driver.
This does add another active component to the rootfs
but keeping time scychorized is crucial.

Fixes #255

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>