### PR TITLE
builder: Pass the DEBUG flag when using docker

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -117,6 +117,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 		--env IMG_SIZE="${IMG_SIZE}" \
 		--env AGENT_INIT=${AGENT_INIT} \
 		--env DAX="${DAX}" \
+		--env DEBUG="${DEBUG}" \
 		-v /dev:/dev \
 		-v "${script_dir}":"/osbuilder" \
 		-v "${script_dir}/../scripts":"/scripts" \

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -346,6 +346,7 @@ if [ -n "${USE_DOCKER}" ] ; then
 		--env OSBUILDER_VERSION="${OSBUILDER_VERSION}" \
 		--env INSIDE_CONTAINER=1 \
 		--env SECCOMP="${SECCOMP}" \
+		--env DEBUG="${DEBUG}" \
 		-v "${script_dir}":"/osbuilder" \
 		-v "${ROOTFS_DIR}":"/rootfs" \
 		-v "${script_dir}/../scripts":"/scripts" \


### PR DESCRIPTION
When using docker, pass the `DEBUG` flag to trace the commands as well.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>