### PR TITLE
image-builder: re-implement image builder script

### DIFF
--- a/image-builder/Dockerfile
+++ b/image-builder/Dockerfile
@@ -7,4 +7,4 @@ From fedora:latest
 
 RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
 
-RUN dnf install -y qemu-img parted gdisk e2fsprogs gcc
+RUN dnf install -y qemu-img parted gdisk e2fsprogs gcc xfsprogs

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -6,10 +6,15 @@
 
 set -e
 
-die()
+error()
 {
 	local msg="$*"
 	echo "ERROR: ${msg}" >&2
+}
+
+die()
+{
+	error "$*"
 	exit 1
 }
 

--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -465,13 +465,6 @@ test_distros()
 		IMAGES_BUILD_DEST="$images_dir" \
 		DEBUG=1 )
 
-
-	# Only firecracker doesn't support NVDIMM
-	if [ "${KATA_HYPERVISOR}" != "firecracker" ]; then
-		commonMakeVars+=(DAX="yes")
-	fi
-
-
 	echo -e "$separator"
 
 	# If a distro was specified, filter out the distro list to only include that distro

--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -462,7 +462,8 @@ test_distros()
 	local commonMakeVars=( \
 		USE_DOCKER=true \
 		ROOTFS_BUILD_DEST="$tmp_rootfs" \
-		IMAGES_BUILD_DEST="$images_dir" )
+		IMAGES_BUILD_DEST="$images_dir" \
+		DEBUG=1 )
 
 
 	# Only firecracker doesn't support NVDIMM


### PR DESCRIPTION
Re-implement image builder script to generate an image with a double MBR +
a DAX metadata. The DAX metadata is read by the NVDIMM driver to know the
beginning of the data in the pmem device.
This new image format is required to enable DAX in the kernels and hypervisors
that support NVDIMM, without breaking the compatibility with the kernels and
hypervisors that don't support it.

Following diagram shows how the resulting image will look like

```
    .-----------.----------.---------------.-----------.
    | 0 - 512 B | 4 - 8 Kb |  2M - 2M+512B |    3M     |
    |-----------+----------+---------------+-----------+
    |   MBR #1  |   DAX    |    MBR #2     |  Rootfs   |
    '-----------'----------'---------------'-----------+
          |          |      ^      |        ^
          |          '-data-'      '--------'
          |                                 |
          '--------rootfs-partition---------'
```

MBR: Master boot record.
DAX: Metadata required by the NVDIMM driver to enable DAX in the guest [1][2]
(struct nd_pfn_sb).
Rootfs: partition that contains the root filesystem (/usr, /bin, etc).

Kernels and hypervisors that support DAX/NVDIMM read the MBR #2,
otherwise MBR #1 is read.

[1] - https://github.com/kata-containers/osbuilder/blob/master/image-builder/\
nsdax.gpl.c
[2] - https://github.com/torvalds/linux/blob/master/drivers/nvdimm/pfn.h

fixes #263

Signed-off-by: Julio Montes <julio.montes@intel.com>
