### PR TITLE
chrony: Configure chrony to start only when /dev/ptp0 exists.

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -410,6 +410,15 @@ echo "refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0" >> ${chrony_conf_file}
 # Reference:  https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html
 sed -i 's/^\(server \|pool \|peer \)/# &/g'  ${chrony_conf_file}
 
+chrony_systemd_service="${ROOTFS_DIR}/usr/lib/systemd/system/chronyd.service"
+if [ ${distro} == ubuntu ] || [ ${distro} == debian ] ; then
+	chrony_systemd_service="${ROOTFS_DIR}/lib/systemd/system/chrony.service"
+fi
+
+if [ -f "$chrony_systemd_service" ]; then
+	sed -i '/^\[Unit\]/a ConditionPathExists=\/dev\/ptp0' ${chrony_systemd_service}
+fi
+
 # The CC on s390x for fedora needs to be manually set to gcc when the golang is downloaded from the main page.
 # See issue: https://github.com/kata-containers/osbuilder/issues/217
 [ "$distro" == fedora ] && [ "$ARCH" == "s390x" ] && export CC=gcc


### PR DESCRIPTION
Hypercall to implement virtual PTP was introduced in kernel 4.10
Have chrony run only if the device created by kvm-ptp exists.
Add this as a ConditionExists in the systemd service file.

This service if named as chrony.service in deb based distributions
rather than chronyd.service, although a systemd alias exists.
However it is not possible to come up with a generic `PATH` systemd
unit relying on the alias.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>