### PR TITLE
rootfs-builder: remove /var/log

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -379,7 +379,7 @@ fi
 build_rootfs ${ROOTFS_DIR}
 pushd "${ROOTFS_DIR}" >> /dev/null
 if [ "$PWD" != "/" ] ; then
-	rm -rf ./var/cache/ ./var/lib
+	rm -rf ./var/cache/ ./var/lib ./var/log
 fi
 popd  >> /dev/null
 


### PR DESCRIPTION
/var/log is not required in the rootfs

fixes #254

Signed-off-by: Julio Montes <julio.montes@intel.com>