### PR TITLE
rootfs-builder: fix chrony service

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -381,6 +381,10 @@ pushd "${ROOTFS_DIR}" >> /dev/null
 if [ "$PWD" != "/" ] ; then
 	rm -rf ./var/cache/ ./var/lib
 fi
+
+info "Create symlink to /tmp in /var to create private temporal directories with systemd"
+rm -rf ./var/tmp
+ln -s ../tmp ./var/
 popd  >> /dev/null
 
 [ -n "${KERNEL_MODULES_DIR}" ] && copy_kernel_modules ${KERNEL_MODULES_DIR} ${ROOTFS_DIR}


### PR DESCRIPTION
Chrony service is not started because it requires a private temporal directory,
these directories can't be created in read-only filesystems. Remove
`PrivateTmp` from chrony service file.

fixes #280

Signed-off-by: Julio Montes <julio.montes@intel.com>