### PR TITLE
make: add nsdax source to install-scripts target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,10 @@ SCRIPTS += rootfs-builder/rootfs.sh
 SCRIPTS += image-builder/image_builder.sh
 SCRIPTS += initrd-builder/initrd_builder.sh
 
-FILES :=
-FILES += rootfs-builder/versions.txt
-FILES += scripts/lib.sh
+HELPER_FILES :=
+HELPER_FILES += rootfs-builder/versions.txt
+HELPER_FILES += scripts/lib.sh
+HELPER_FILES += image-builder/nsdax.gpl.c
 
 define INSTALL_FILE
 	echo "Installing $(abspath $2/$1)";
@@ -117,7 +118,7 @@ install-scripts:
 	@echo "Installing scripts"
 	@$(foreach f,$(SCRIPTS),$(call INSTALL_SCRIPT,$f,$(INSTALL_DIR)))
 	@echo "Installing helper files"
-	@$(foreach f,$(FILES),$(call INSTALL_FILE,$f,$(INSTALL_DIR)))
+	@$(foreach f,$(HELPER_FILES),$(call INSTALL_FILE,$f,$(INSTALL_DIR)))
 	@echo "Installing installing config files"
 	@$(foreach f,$(DIST_CONFIGS),$(call INSTALL_FILE,$f,$(INSTALL_DIR)))
 

--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -34,6 +34,10 @@ readonly dax_header_sz=2
 # [2] - https://nvdimm.wiki.kernel.org/2mib_fs_dax
 readonly dax_alignment=2
 
+# Set a default value
+AGENT_INIT=${AGENT_INIT:-no}
+
+
 # In order to support memory hotplug, image must be aligned to
 # memory section(size in MB) according to different architecture.
 case "$(uname -m)" in


### PR DESCRIPTION
- make: add nsdax source to install-scripts target (nsdax.gpl.c is required by image_builder.sh).  Fixes: #283
- image-builder: set default value of AGENT_INIT
