### PR TITLE
image-builder/boot time: remove unneeded systemd units and files

### DIFF
--- a/image-builder/Dockerfile
+++ b/image-builder/Dockerfile
@@ -7,4 +7,4 @@ From fedora:latest
 
 RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
 
-RUN dnf install -y qemu-img parted gdisk e2fsprogs gcc xfsprogs
+RUN dnf install -y qemu-img parted gdisk e2fsprogs gcc xfsprogs findutils


### PR DESCRIPTION
Remove systemd units and files that are not needed in Kata Containers.
Removing this files we can improve the boot time.

fixes #289

![1](https://user-images.githubusercontent.com/13009432/57870377-8df22080-77cc-11e9-9034-2fbb6602bebb.png)

`before` = with all systemd files and units
`after` = without unneeded systemd files and units (this patch)


cc @grahamwhaley @jodh-intel @bergwolf 

Signed-off-by: Julio Montes <julio.montes@intel.com>