### PR TITLE
rootfs: Don't hardcode alpine version for golang images

### DIFF
--- a/rootfs-builder/alpine/Dockerfile.in
+++ b/rootfs-builder/alpine/Dockerfile.in
@@ -3,6 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From golang:@GO_VERSION@-alpine3.7
+From golang:@GO_VERSION@-alpine
 
 RUN apk update && apk add git make bash gcc musl-dev linux-headers apk-tools-static libseccomp libseccomp-dev


### PR DESCRIPTION
Remove the version of alpine used when pulling golang docker images. This ensures the latest version of alpine is used and resolves the maintenance issue when old versions of alpine are dropped.

Fixes: #293.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>