### PR TITLE
image-builder: create /etc/machine-id

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -382,6 +382,9 @@ create_rootfs_image() {
 		find "${mount_dir}" -type f -name "${u}" -exec rm -f {} \;
 	done
 
+	info "Creating empty machine-id to allow systemd to bind-mount it"
+	touch "${mount_dir}/etc/machine-id"
+
 	info "Unmounting root partition"
 	umount "${mount_dir}"
 	OK "Root partition unmounted"


### PR DESCRIPTION
systemd complains if `/etc/machine-id` does not exist. Create the `machine-id`
file to make systemd happy, it'll bind-mount that file to write the machine id.

fixes #296
fixes github.com/kata-containers/runtime#1537

Signed-off-by: Julio Montes <julio.montes@intel.com>