### PR TITLE
tmp: Do not remove tmp.mount unit file from the rootfs

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -56,7 +56,6 @@ readonly -a systemd_files=(
 	"systemd-getty-generator"
 	"systemd-gpt-auto-generator"
 	"systemd-tmpfiles-cleanup.timer"
-	"tmp.mount"
 )
 
 # Set a default value


### PR DESCRIPTION
We should start this unit so that systemd can mount /tmp as
tmpfs.

Fixes #300

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>