### PR TITLE
clear: Add util-linux-bin package to Clearlinux rootfs

### DIFF
--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -15,7 +15,7 @@ clr_url="https://download.clearlinux.org"
 
 BASE_URL="${clr_url}/releases/${OS_VERSION}/${REPO_NAME}/${ARCH}/os/"
 
-PACKAGES="iptables-bin libudev0-shim chrony"
+PACKAGES="util-linux-bin iptables-bin libudev0-shim chrony"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent


### PR DESCRIPTION
This package contains mount command among several other commands.
Unlike other distros, this package is not auto-pulled with systemd.
Add this package explicitly.

Fixes #302

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>