### PR TITLE
rootfs: install systemd tmp.mount if needed

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -385,6 +385,15 @@ fi
 info "Create symlink to /tmp in /var to create private temporal directories with systemd"
 rm -rf ./var/tmp
 ln -s ../tmp ./var/
+
+# For some distros tmp.mount may not be installed by default in systemd paths
+if ! [ -f "./etc/systemd/system/tmp.mount" ] && \
+   ! [ -f "./usr/lib/systemd/system/tmp.mount" ] &&
+   [ "$AGENT_INIT" != "yes" ]; then
+	info "Install tmp.mount in ./etc/systemd/system"
+	cp ./usr/share/systemd/tmp.mount ./etc/systemd/system/tmp.mount
+fi
+
 popd  >> /dev/null
 
 [ -n "${KERNEL_MODULES_DIR}" ] && copy_kernel_modules ${KERNEL_MODULES_DIR} ${ROOTFS_DIR}

--- a/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -13,12 +13,12 @@
 #
 # BIN_AGENT: Name of the Kata-Agent binary
 #
-# REPO_URL: URL to distribution repository ( should be configured in 
+# REPO_URL: URL to distribution repository ( should be configured in
 #			config.sh file)
 #
-# Any other configuration variable for a specific distro must be added 
+# Any other configuration variable for a specific distro must be added
 # and documented on its own config.sh
-# 
+#
 # - Expected result
 #
 # rootfs_dir populated with rootfs pkgs
@@ -65,19 +65,19 @@ build_rootfs() {
 	# This is done to maintain consistency
 	PACKAGES=$(echo $PACKAGES | sed  -e 's/ /,/g' )
 	EXTRA_PKGS=$(echo $EXTRA_PKGS | sed  -e 's/ /,/g' )
-	
+
 	# extra packages are added to packages and finally passed to debootstrap
 	if [ "${EXTRA_PKGS}" = ""  ]; then
 		echo "no extra packages"
 	else
 		PACKAGES="${PACKAGES},${EXTRA_PKGS}"
 	fi
-	
+
 	${PKG_MANAGER} --variant=minbase \
 		--arch=${ARCHITECTURE}\
 		--include="$PACKAGES" \
 		${OS_NAME} \
-		${ROOTFS_DIR} 
+		${ROOTFS_DIR}
 
 	chroot $ROOTFS_DIR ln -s /lib/systemd/systemd /usr/lib/systemd/systemd
 }


### PR DESCRIPTION
~~On Debian / Ubuntu, tmp.mount is not installed in
/[etc|usr/lib]/systemd/system by default, but in
/usr/shared/systemd, and need to be manually copied there
to have /tmp mounted as tmpfs.~~

On some distros (Debian, Ubuntu, openSUSE), tmp.mount is not
installed by default in /[etc|usr/lib]/systemd/system, but
just in /usr/shared/systemd, so it needs to be manually copied
there to have /tmp mounted as tmpfs.

Fixes: #317

Signed-off-by: Marco Vedovati <mvedovati@suse.com>