### PR TITLE
rootfs-builder: exclude unsupported archs from euleros and clearlinux

### DIFF
--- a/rootfs-builder/clearlinux/config.sh
+++ b/rootfs-builder/clearlinux/config.sh
@@ -26,6 +26,6 @@ PACKAGES="util-linux-bin iptables-bin libudev0-shim chrony"
 INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
-ARCH_EXCLUDE_LIST=(ppc64le)
+ARCH_EXCLUDE_LIST=( aarch64 ppc64le s390x )
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp" || true

--- a/rootfs-builder/euleros/config.sh
+++ b/rootfs-builder/euleros/config.sh
@@ -21,7 +21,7 @@ PACKAGES="iptables chrony"
 INIT_PROCESS=systemd
 # List of zero or more architectures to exclude from build,
 # as reported by  `uname -m`
-ARCH_EXCLUDE_LIST=()
+ARCH_EXCLUDE_LIST=( aarch64 ppc64le s390x )
 # Allow the build to fail without generating an error.
 # For more info see: https://github.com/kata-containers/osbuilder/issues/190
 BUILD_CAN_FAIL=1


### PR DESCRIPTION
# Description of problem
For clearlinux, for now, it is only designed for amd64.
For euleros, it has supported aarch64 starting from 2.3, but here is the sad part. 
there existed bugs in their 2.3.x image, this bug existed in both x86_64 and aarch64 image. related issue [euleros/euleros-docker-images/#13](https://github.com/euleros/euleros-docker-images/issues/13) has been raised.
since x86_64 is using version 2.2, it's fine there, stay on that.😎 