### PR TITLE
image-builder: get mount directory size with Mb format

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -233,7 +233,7 @@ calculate_required_disk_size() {
 			die "Could not format loop device: ${device}"
 		fi
 		mount "${device}p1" "${mount_dir}"
-		avail="$(df -h --output=avail "${mount_dir}" | tail -n1 | sed 's/[M ]//g')"
+		avail="$(df -BM --output=avail "${mount_dir}" | tail -n1 | sed 's/[M ]//g')"
 		umount "${mount_dir}"
 		losetup -d "${device}"
 


### PR DESCRIPTION
The available directory size  calculated as Gb while creating a bigger custom image.  
This little fix makes it comparable  with `${rootfs_size_mb}` and tested to be useful.

Signed-off-by: ClarkLee <clarklee1992@hotmail.com>