### PR TITLE
rootfs: Make sure etc exists.

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -459,6 +459,9 @@ if [ ${distro} == ubuntu ] || [ ${distro} == debian ] ; then
 	chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
 fi
 
+info "Create ${ROOTFS_DIR}/etc"
+mkdir -p "${ROOTFS_DIR}/etc"
+
 info "Configure chrony file ${chrony_conf_file}"
 cat >> "${chrony_conf_file}" <<EOT
 refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0


### PR DESCRIPTION
We are seeing sporadic failures in the rootfs creation as listed here:
https://github.com/kata-containers/tests/issues/1744

While this cannot be reproduced locally, there is no reason
for the failure to write to $ROOTFS_DIR/etc/chrony.conf unless the upper
directories are missing as this file should be created if it did not
exist earier.
So just create the etc directory to test out if we see these sporadic
failures in the CI.

Fixes #328

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>