### PR TITLE
rootfs: upgrade docker images for fedora

### DIFF
--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -3,20 +3,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From fedora:27
+From fedora:30
 
 @SET_PROXY@
 
 RUN dnf -y update && dnf install -y \
-git \
-systemd \
-pkgconfig \
+chrony \
+curl \
 gcc \
-coreutils \
+git \
 libseccomp \
 libseccomp-devel \
-chrony \
-curl
+make \
+pkgconfig \
+systemd
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/fedora/Dockerfile.in
+++ b/rootfs-builder/fedora/Dockerfile.in
@@ -8,16 +8,16 @@ From fedora:@OS_VERSION@
 @SET_PROXY@
 
 RUN dnf -y update && dnf install -y \
-git \
-redhat-release \
-systemd \
-pkgconfig \
+chrony \
+curl \
 gcc \
-make \
+git \
 libseccomp \
 libseccomp-devel \
-chrony \
-curl
+make \
+pkgconfig \
+redhat-release \
+systemd
 
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Fedora"
 
-OS_VERSION=${OS_VERSION:-28}
+OS_VERSION=${OS_VERSION:-30}
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"
 


### PR DESCRIPTION
Use fedora 30 in docker images.

Fixes: #331