### PR TITLE
fedora-rootfs: using fedora 28 on aarch64

### DIFF
--- a/rootfs-builder/fedora/config_aarch64.sh
+++ b/rootfs-builder/fedora/config_aarch64.sh
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# image busybox will fail on fedora 30 rootfs image
+# see https://github.com/kata-containers/osbuilder/issues/334 for detailed info
+OS_VERSION="28"
+
+MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"


### PR DESCRIPTION
Lately, PR #332 has upgraded fedora from 28 to 30 in docker image when building the fedora rootfs.
And it caused the busybox image crashed and bring ARM CI down [#ci/205](https://github.com/kata-containers/ci/issues/205). 
I have collected some related log from `kata-agent`.
```
Jul 23 11:15:48  kata-proxy[33284]: time="2019-07-23T11:15:48.416884388+08:00" level=info msg="systemd-coredump[81]: Failed to send coredump datagram: Broken pipe\n" name=kata-proxy pid=33284 sandbox=3c7bccc707d8512f5ae2a99ae85d5d7208c52d1d50754a03ca7f086cf050eccc source=agent
Jul 23 11:15:48 kata-proxy[33284]: time="2019-07-23T11:15:48.419322078+08:00" level=info msg="time=\"2019-07-23T03:15:48.122604785Z\" level=debug msg=\"process exited\" debug_console=false name=kata-agent pid=76 sandbox=3c7bccc707d8512f5ae2a99ae85d5d7208c52d1d50754a03ca7f086cf050eccc source=agent status=139\n" name=kata-proxy pid=33284 sandbox=3c7bccc707d8512f5ae2a99ae85d5d7208c52d1d50754a03ca7f086cf050eccc source=agent
```
It looked to me that `systemd-coredump` had something wrong with writing coredump, `Broken pipe error`. But I don't know why??? 😢
I will keep digging up. But, firstly, in order to bring ARM CI back, we need to switch back to use fedora 28 on aarch64