### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -170,7 +170,7 @@ create_summary_file()
 	local -r filename="osbuilder.yaml"
 	local file="${dir}/${filename}"
 
-	local -r now=$(date '+%Y-%m-%dT%T.%N%zZ')
+	local -r now=$(date -u -d@${SOURCE_DATE_EPOCH:-$(date +%s.%N)} '+%Y-%m-%dT%T.%N%zZ')
 
 	# sanitise package lists
 	PACKAGES=$(echo "$PACKAGES"|tr ' ' '\n'|sort -u|tr '\n' ' ')


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use UTC to be independent of timezone.

Note: This date call only works with GNU date.

Without this patch, `kata-containers-initrd.img` contained a varying `var/lib/osbuilder/osbuilder.yaml` with
```diff
 osbuilder:
   url: "https://github.com/kata-containers/osbuilder"
   version: "1.9.0-alpha0"
-rootfs-creation-time: "2019-08-06T18:40:27.402493939+0000Z"
+rootfs-creation-time: "2034-09-08T07:57:34.386990704+0000Z"
```

This PR was done while working on reproducible builds for openSUSE.