### PR TITLE
image_builder: create /etc/resolv.conf

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -391,6 +391,9 @@ create_rootfs_image() {
 	info "Creating empty machine-id to allow systemd to bind-mount it"
 	touch "${mount_dir}/etc/machine-id"
 
+	info "Creating empty resolv.conf to allow kata-agent to bind-mount it"
+	touch "${mount_dir}/etc/resolv.conf"
+
 	info "Unmounting root partition"
 	umount "${mount_dir}"
 	OK "Root partition unmounted"


### PR DESCRIPTION
Since the image rootfs is readonly, we
create an empty /etc/resolv.conf which
the agent would later bind-remount as
read-write.

Fixes: #345

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>