### PR TITLE
rootfs: fix service start fail issue for arm64

### DIFF
--- a/rootfs-builder/fedora/config_aarch64.sh
+++ b/rootfs-builder/fedora/config_aarch64.sh
@@ -5,6 +5,6 @@
 
 # image busybox will fail on fedora 30 rootfs image
 # see https://github.com/kata-containers/osbuilder/issues/334 for detailed info
-OS_VERSION="28"
+OS_VERSION="29"
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"


### PR DESCRIPTION
Now, fedora:28 is chosen by arm64 to build rootfs. but
systemd service enable PrivateTmp will fail to start when
/var/tmp linked to /tmp due to mount failure of private directory
under /var/tmp.
This patch cancel this link for arm64.

Fixes: #347
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
@jodh-intel  @grahamwhaley  