### PR TITLE
rootfs: update fedora to 29 for arm64.

### DIFF
--- a/rootfs-builder/fedora/config_aarch64.sh
+++ b/rootfs-builder/fedora/config_aarch64.sh
@@ -5,6 +5,6 @@
 
 # image busybox will fail on fedora 30 rootfs image
 # see https://github.com/kata-containers/osbuilder/issues/334 for detailed info
-OS_VERSION="28"
+OS_VERSION="29"
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"


### PR DESCRIPTION
there is issue in fedora:28 when start systemd service.
update fedora to 29 will bypass this issue.

Fixes: #349
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
@devimc @marcov @jcvenegas 