### PR TITLE
make: use bash to fetch dracut conf 'drivers' list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ ifeq (dracut,$(BUILD_METHOD))
   DRACUT_OPTIONS     := --no-compress --conf /dev/null --confdir $(DRACUT_CONF_DIR)
 
   ifneq (,$(DRACUT_KVERSION))
-    # If a kernel version is not specified, do not make systemd load modules
-    # at startup
     DRACUT_KMODULES  := $(shell grep "^drivers=" $(DRACUT_CONF_DIR)/10-drivers.conf | sed -E "s,^drivers=\"(.*)\"$$,\1,")
   else
+    # If a kernel version is not specified, do not make systemd load modules
+    # at startup
     DRACUT_OPTIONS += --no-kernel
   endif
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ ifeq (dracut,$(BUILD_METHOD))
   DRACUT_OPTIONS     := --no-compress --conf /dev/null --confdir $(DRACUT_CONF_DIR)
 
   ifneq (,$(DRACUT_KVERSION))
-    DRACUT_KMODULES  := $(shell grep "^drivers=" $(DRACUT_CONF_DIR)/10-drivers.conf | sed -E "s,^drivers=\"(.*)\"$$,\1,")
+    # Explicitly use bash, which is what dracut uses to process conf files
+    DRACUT_KMODULES  := $(shell bash -c 'source $(DRACUT_CONF_DIR)/10-drivers.conf; echo "$$drivers"')
   else
     # If a kernel version is not specified, do not make systemd load modules
     # at startup


### PR DESCRIPTION
dracut will process conf files with bash, and in fact it's common to use idioms like += in conf files for string concatenation. The current grep usage in the Makefile won't catch all possible valid 'drivers'
variable cases.

Instead, use bash to parse and echo the 'drivers' content

Fixes: #356