### PR TITLE
initrd_builder: Create empty resolv.conf in rootfs

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -391,9 +391,6 @@ create_rootfs_image() {
 	info "Creating empty machine-id to allow systemd to bind-mount it"
 	touch "${mount_dir}/etc/machine-id"
 
-	info "Creating empty resolv.conf to allow kata-agent to bind-mount it"
-	touch "${mount_dir}/etc/resolv.conf"
-
 	info "Unmounting root partition"
 	umount "${mount_dir}"
 	OK "Root partition unmounted"

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -510,6 +510,15 @@ EOT
 	[ -x "${init}" ] || [ -L "${init}" ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"
 	OK "init is installed"
 
+	# Create an empty /etc/resolv.conf, to allow agent to bind mount container resolv.conf to Kata VM
+	dns_file="${ROOTFS_DIR}/etc/resolv.conf"
+	if [ -L "$dns_file" ]; then
+		# if /etc/resolv.conf is a link, it cannot be used for bind mount
+		rm -f "$dns_file"
+	fi
+	info "Create /etc/resolv.conf file in rootfs if not exist"
+	touch "$dns_file"
+
 	info "Creating summary file"
 	create_summary_file "${ROOTFS_DIR}"
 }


### PR DESCRIPTION
Create an empty /etc/resolv.conf in initrd rootfs
so that the agent can bind mount it for DNS in
kata VM.

Fixes: #365

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>