### PR TITLE
osbuilder: Add USE_PODMAN as an alternate for USE_DOCKER

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ distro specific commands (e.g.: `debootstrap` for Debian or `yum` for CentOS).
 The `dracut` build method uses the distro-agnostic tool `dracut` to obtain the same goal.
 
 By default components are run on the host system. However, some components
-offer the ability to run from within Docker (for ease of setup) by setting the
-`USE_DOCKER=true` variable.
+offer the ability to run from within a container (for ease of setup) by setting the
+`USE_DOCKER=true` or `USE_PODMAN=true` variable. If both are set, `USE_DOCKER=true`
+takes precedence over `USE_PODMAN=true`.
 
 For more detailed information, consult the documentation for a particular component.
 

--- a/image-builder/Dockerfile
+++ b/image-builder/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From fedora:latest
+From docker.io/fedora:latest
 
 RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
 

--- a/rootfs-builder/alpine/Dockerfile.in
+++ b/rootfs-builder/alpine/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From golang:@GO_VERSION@-alpine
+From docker.io/golang:@GO_VERSION@-alpine
 
 RUN apk update && apk add \
     git \

--- a/rootfs-builder/centos/Dockerfile.in
+++ b/rootfs-builder/centos/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From centos:@OS_VERSION@
+From docker.io/centos:@OS_VERSION@
 
 @SET_PROXY@
 

--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From fedora:30
+From docker.io/fedora:30
 
 @SET_PROXY@
 

--- a/rootfs-builder/debian/Dockerfile.in
+++ b/rootfs-builder/debian/Dockerfile.in
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # NOTE: OS_VERSION is set according to config.sh
-from debian:@OS_VERSION@
+from docker.io/debian:@OS_VERSION@
 
 # RUN commands
 RUN apt-get update && apt-get install -y curl wget systemd debootstrap git build-essential chrony

--- a/rootfs-builder/euleros/Dockerfile.in
+++ b/rootfs-builder/euleros/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM euleros:@OS_VERSION@
+FROM docker.io/euleros:@OS_VERSION@
 
 @SET_PROXY@
 

--- a/rootfs-builder/fedora/Dockerfile.in
+++ b/rootfs-builder/fedora/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From fedora:@OS_VERSION@
+From docker.io/fedora:@OS_VERSION@
 
 @SET_PROXY@
 

--- a/rootfs-builder/suse/Dockerfile.in
+++ b/rootfs-builder/suse/Dockerfile.in
@@ -5,7 +5,7 @@
 
 #suse: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
-from opensuse/leap
+from docker.io/opensuse/leap
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)

--- a/rootfs-builder/ubuntu/Dockerfile.in
+++ b/rootfs-builder/ubuntu/Dockerfile.in
@@ -5,7 +5,7 @@
 
 #ubuntu: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
-from ubuntu:@OS_VERSION@
+from docker.io/ubuntu:@OS_VERSION@
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)


### PR DESCRIPTION
    In case a user wants to use podman instead of
    docker to build initrd/rootfs images, facilitate
    it by setting the variable `USE_PODMAN=true`.
    
    Fixes: #370
    
    Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>