### PR TITLE
rootfs-builder/alpine: use latest stable

### DIFF
--- a/rootfs-builder/alpine/config.sh
+++ b/rootfs-builder/alpine/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Alpine"
 
-OS_VERSION=${OS_VERSION:-v3.7}
+OS_VERSION=${OS_VERSION:-latest-stable}
 
 BASE_PACKAGES="alpine-base"
 


### PR DESCRIPTION
use latest stable to fix CVEs

fixes #379

Signed-off-by: Julio Montes <julio.montes@intel.com>