### PR TITLE
make: use `cd` instead of '--directory' option of `cpio`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX):: rootfs-builder/%
 .PRECIOUS: $(ROOTFS_BUILD_DEST)/.dracut$(ROOTFS_MARKER_SUFFIX)
 $(ROOTFS_BUILD_DEST)/.dracut$(ROOTFS_MARKER_SUFFIX): $(TARGET_INITRD)
 	mkdir -p $(TARGET_ROOTFS)
-	cat $< | cpio --extract --preserve-modification-time --make-directories --directory=$(TARGET_ROOTFS)
+	(cd $(TARGET_ROOTFS); cat $< | cpio --extract --preserve-modification-time --make-directories)
 	@touch $@
 
 image-%: $(IMAGES_BUILD_DEST)/kata-containers-image-%.img


### PR DESCRIPTION
Due to the option '--directory' just added from 'cpio' v2.12, so the
osbuilder will failed with old version 'cpio' before v2.12, such as in
Centos 7 with v2.11.
Fix it by replacing this option with '(cd ...; cat ...)'.

Fixes: #384

Signed-off-by: Shile Zhang <shile.zhang@linux.alibaba.com>