### PR TITLE
image_builder: Remove nsdax binary after its usage

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -425,6 +425,7 @@ set_dax_header() {
 	# Issue: https://github.com/kata-containers/osbuilder/issues/240
 	gcc -O2 "${script_dir}/nsdax.gpl.c" -o "${script_dir}/nsdax"
 	"${script_dir}/nsdax" "${header_image}" "${dax_header_bytes}" "${dax_alignment_bytes}"
+	rm -f "${script_dir}/nsdax"
 	sync
 
 	touch "${dax_image}"


### PR DESCRIPTION
Leaving nsdax behind may create some isses for the distro packages
of kata-osbuilder, as every package would have to take care of purging
the file on each distro.

Knowing that, we better remove the file as part of the script, mainly
because the file is already regenerated everytime in any case.

Fixes: #394

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>