### PR TITLE
image-builder: make docker runtime configurable

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -8,6 +8,8 @@ set -e
 
 [ -n "${DEBUG}" ] && set -x
 
+DOCKER_RUNTIME=${DOCKER_RUNTIME:-runc}
+
 readonly script_name="${0##*/}"
 readonly script_dir=$(dirname "$(readlink -f "$0")")
 readonly lib_file="${script_dir}/../scripts/lib.sh"
@@ -149,7 +151,7 @@ build_with_container() {
 	#https://github.com/clearcontainers/runtime/issues/828
 	"${container_engine}" run  \
 		   --rm \
-		   --runtime runc  \
+		   --runtime "${DOCKER_RUNTIME}"  \
 		   --privileged \
 		   --env AGENT_BIN="${agent_bin}" \
 		   --env AGENT_INIT="${agent_init}" \


### PR DESCRIPTION
Add DOCKER_RUNTIME variable to change container runtime depending on the
CI/environment.

fixes #397

Signed-off-by: Julio Montes <julio.montes@intel.com>