### PR TITLE
osbuilder: Update Fedora version

### DIFF
--- a/rootfs-builder/centos/Dockerfile.in
+++ b/rootfs-builder/centos/Dockerfile.in
@@ -11,9 +11,7 @@ RUN yum -y update && yum install -y \
 git \
 make \
 gcc \
-coreutils \
 libseccomp \
-libseccomp-devel \
 chrony \
 curl
 

--- a/rootfs-builder/centos/config.sh
+++ b/rootfs-builder/centos/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Centos"
 
-OS_VERSION=${OS_VERSION:-7}
+OS_VERSION=${OS_VERSION:-8}
 
 LOG_FILE="/var/log/yum-centos.log"
 

--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From docker.io/fedora:30
+From docker.io/fedora:31
 
 @SET_PROXY@
 

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Fedora"
 
-OS_VERSION=${OS_VERSION:-30}
+OS_VERSION=${OS_VERSION:-31}
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"
 


### PR DESCRIPTION
Currently we have some random failures while trying to retrieve Fedora 30
repositories. This PR updates the fedora version in order to avoid this.

Fixes #402

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>