### PR TITLE
image_builder: Reduce the boundary mb for reducing image size on arm64

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -63,11 +63,9 @@ readonly -a systemd_files=(
 # Set a default value
 AGENT_INIT=${AGENT_INIT:-no}
 
-
-# In order to support memory hotplug, image must be aligned to
-# memory section(size in MB) according to different architecture.
+# Align image to (size in MB) according to different architecture.
 case "$(uname -m)" in
-	aarch64) readonly mem_boundary_mb=1024 ;;
+	aarch64) readonly mem_boundary_mb=16 ;;
 	*) readonly mem_boundary_mb=128 ;;
 esac
 


### PR DESCRIPTION
Qemu merely limits the memory-backend-file size to be aligned to page_size
instead of section size(arm64 1GB). Please see file_ram_alloc() in qemu
exec.c. If we use 1024MB, the generated image size will be 3-4 times bigger
than the original one.

After relaxing it, the image size will be changed from 1G to 300M+ on arm64
with Fedora 29 rootfs's default configuration.

I do see there are some different limitation for ram_block on other arches
(e.g. s390x). So gracefully keep other arches unchanged here.

Fixes #404
Signed-off-by: Jia He <justin.he@arm.com>