### PR TITLE
AArch64: Build rust image on aarch64

### DIFF
--- a/rootfs-builder/debian/Dockerfile-aarch64.in
+++ b/rootfs-builder/debian/Dockerfile-aarch64.in
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2020 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: OS_VERSION is set according to config.sh
+from docker.io/debian:@OS_VERSION@
+
+# RUN commands
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    binutils \
+    build-essential \
+    chrony \
+    cmake \
+    coreutils \
+    curl \
+    debianutils \
+    debootstrap \
+    g++ \
+    gcc \
+    git \
+    libc-dev \
+    libstdc++-6-dev \
+    m4 \
+    make \
+    sed \
+    systemd \
+    tar \
+    vim
+# This will install the proper golang to build Kata components
+@INSTALL_GO@
+@INSTALL_MUSL@
+@INSTALL_RUST@

--- a/rootfs-builder/ubuntu/Dockerfile-aarch64.in
+++ b/rootfs-builder/ubuntu/Dockerfile-aarch64.in
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2020 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#ubuntu: docker image to be used to create a rootfs
+#@OS_VERSION@: Docker image version to build this dockerfile
+from docker.io/ubuntu:@OS_VERSION@
+
+# This dockerfile needs to provide all the componets need to build a rootfs
+# Install any package need to create a rootfs (package manager, extra tools)
+
+# RUN commands
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    binutils \
+    build-essential \
+    chrony \
+    cmake \
+    coreutils \
+    curl \
+    debianutils \
+    debootstrap \
+    g++ \
+    gcc \
+    git \
+    libc6-dev \
+    libstdc++-8-dev \
+    m4 \
+    make \
+    sed \
+    systemd \
+    tar \
+    vim
+# This will install the proper golang to build Kata components
+@INSTALL_GO@
+@INSTALL_MUSL@
+@INSTALL_RUST@

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -199,7 +199,7 @@ create_summary_file()
 	if [ "${RUST_AGENT}" == "no" ]; then
 		agent_version=$("$agent" --version|awk '{print $NF}')
 	else
-		local -r agentdir="${RUST_SRC_PATH}/$(basename ${RUST_AGENT_PKG} .git)/src/agent"
+		local -r agentdir="${GOPATH}/src/${RUST_AGENT_PKG}/src/agent"
 		agent_version=$(cat ${agentdir}/VERSION)
 	fi
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -296,9 +296,23 @@ RUN pushd /root; \
 	make install > /dev/null 2>\&1; \
 	popd
 "
-	local musl_tar="musl-${MUSL_VERSION}.tar.gz"
-	local musl_dir="musl-${MUSL_VERSION}"
-	readonly install_musl="
+	# install musl for compiling rust-agent
+	install_musl=
+	if [ "${muslarch}" == "aarch64" ]; then
+		local musl_tar="${muslarch}-linux-musl-native.tgz"
+		local musl_dir="${muslarch}-linux-musl-native"
+		install_musl="
+RUN cd /tmp; \
+	curl -sLO https://musl.cc/${musl_tar}; tar -zxf ${musl_tar}; \
+	 mkdir -p /usr/local/musl/; \
+	cp -r ${musl_dir}/* /usr/local/musl/
+ENV PATH=\$PATH:/usr/local/musl/bin
+RUN ln -sf /usr/local/musl/bin/g++ /usr/bin/g++
+"
+	else
+		local musl_tar="musl-${MUSL_VERSION}.tar.gz"
+		local musl_dir="musl-${MUSL_VERSION}"
+		install_musl="
 RUN pushd /root; \
     curl -sLO https://www.musl-libc.org/releases/${musl_tar}; tar -zxf ${musl_tar}; \
 	cd ${musl_dir}; \
@@ -310,6 +324,8 @@ RUN pushd /root; \
 	popd
 ENV PATH=\$PATH:/usr/local/musl/bin
 "
+	fi
+
 	readonly install_rust="
 RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSLf --output /tmp/rust-init; \
     chmod a+x /tmp/rust-init; \


### PR DESCRIPTION
Hi~ guys 
I've been trying to build rust-agent image on AArch64 for a couple days. ;)
The existing method needs a few refinement to work it out. 

- **Install musl on aarch64**
The original musl-installing method is only for `x86_64` and `i386`.
[musl.cc](https://musl.cc/) provides small and reliable pre-built musl tool-chains for many architectures.
Static so they run on supported platforms without dependencies.

- **ubuntu/debian: create aarch64-specific Dockerfile.in**
The musl package in ubuntu/debian(`musl`, `musl-dev`, `musl-tools`) could not provide everything we need on aarch64. 
e.g. we need `aarch64-linux-musl-gcc` as linker, and it's not provided in package.
So I'll use above static tool chains to replace them.

- **rootfs: remove RUST_SRC_PATH** 
If user wants to use customized rust-agent, they could use `AGENT_SOURCE_BIN` to pass the static binary.
The rust-agent is always statically linked with musl.
Therefore, the source code of rust will be placed under `$GOPATH` for better management.

- **rust-agent: Separate the build up of rust-agent and go-agent**
We need to separate the build up of `rust-agent` and `go-agent`, hence you only select one as kata-agent.
I've fired another PR https://github.com/kata-containers/kata-containers/issues/144 to add the generation of rust-agent systemd service files(`kata-agent.service.in`, `kata-containers.target`) into rust-agent Makefile. 
The related command is `make install` or `make build-service`.
