### PR TITLE
rootfs: Don't overwrite /sbin/init if it already exists

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -455,10 +455,18 @@ prepare_overlay()
 {
 	pushd "${ROOTFS_DIR}" > /dev/null
 	mkdir -p ./etc ./lib/systemd ./sbin ./var
-	ln -sf  ./usr/lib/systemd/systemd ./init
-	ln -sf  ../../init ./lib/systemd/systemd
-	ln -sf  ../init ./sbin/init
-	# Kata sytemd unit file
+
+	# This symlink hacking is mostly to make later rootfs
+	# validation work correctly for the dracut case.
+	# We skip this if /sbin/init exists in the rootfs, meaning
+	# we were passed a pre-populated rootfs directory
+	if [ ! -e ./sbin/init ]; then
+		ln -sf  ./usr/lib/systemd/systemd ./init
+		ln -sf  ../../init ./lib/systemd/systemd
+		ln -sf  ../init ./sbin/init
+	fi
+
+	# Kata systemd unit file
 	mkdir -p ./etc/systemd/system/basic.target.wants/
 	ln -sf /usr/lib/systemd/system/kata-containers.target ./etc/systemd/system/basic.target.wants/kata-containers.target
 	popd  > /dev/null


### PR DESCRIPTION
The prepare_overlay() code path is called when rootfs.sh is invoked
with no passed in distro string. This is used for the dracut case
from the Makefile for example. In that particular case, the starting
root directory is empty.

It's also valid to pass a prepopulated directory to rootfs.sh, which
is essentially a request for the script to just make the necessary
kata changes. Currently though prepare_overlay() makes some changes
that could wipe out pre-arranged /sbin/init setup.

Check first to see if /sbin/init exists in the rootfs dir, and if so,
skip the symlink changes

Fixes: #419