### PR TITLE
initrd-builder: Don't error if run as non-root

### DIFF
--- a/initrd-builder/initrd_builder.sh
+++ b/initrd-builder/initrd_builder.sh
@@ -70,8 +70,6 @@ OK "init is installed"
 	use AGENT_BIN env variable to change the expected agent binary name"
 OK "Agent is installed"
 
-[ "$(id -u)" -eq 0 ] || die "$0: must be run as root"
-
 # initramfs expects /init
 ln -sf /sbin/init "${ROOTFS}/init"
 


### PR DESCRIPTION
Nothing inherently requires root here. If the ROOTFS_DIR is only
root accessible then the operation may fail, but better IMO to let
that fail naturally

Fixes: #422