### PR TITLE
pod : optimization Some debian package manager tweaks

### DIFF
--- a/rootfs-builder/debian/Dockerfile.in
+++ b/rootfs-builder/debian/Dockerfile.in
@@ -8,10 +8,12 @@ from docker.io/debian:@OS_VERSION@
 
 # RUN commands
 RUN apt-get update && apt-get --no-install-recommends install -y \
+    apt-utils \
     autoconf \
     automake \
     binutils \
     build-essential \
+    ca-certificates \
     chrony \
     cmake \
     coreutils \

--- a/rootfs-builder/debian/Dockerfile.in
+++ b/rootfs-builder/debian/Dockerfile.in
@@ -7,7 +7,7 @@
 from docker.io/debian:@OS_VERSION@
 
 # RUN commands
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     autoconf \
     automake \
     binutils \

--- a/rootfs-builder/ubuntu/Dockerfile.in
+++ b/rootfs-builder/ubuntu/Dockerfile.in
@@ -11,7 +11,7 @@ from docker.io/ubuntu:@OS_VERSION@
 # Install any package need to create a rootfs (package manager, extra tools)
 
 # RUN commands
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
     autoconf \
     automake \
     binutils \

--- a/rootfs-builder/ubuntu/Dockerfile.in
+++ b/rootfs-builder/ubuntu/Dockerfile.in
@@ -12,10 +12,12 @@ from docker.io/ubuntu:@OS_VERSION@
 
 # RUN commands
 RUN apt-get update && apt-get --no-install-recommends install -y \
+    apt-utils \
     autoconf \
     automake \
     binutils \
     build-essential \
+    ca-certificates \
     chrony \
     cmake \
     coreutils \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Fixes : #427 

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>