### PR TITLE
image_builder: Force mount_dir to be created in /tmp

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -374,7 +374,7 @@ create_rootfs_image() {
 	fi
 
 	info "Mounting root partition"
-	readonly mount_dir=$(mktemp -d osbuilder-mount-dir.XXXX)
+	readonly mount_dir=$(mktemp -p ${TMPDIR:-/tmp} -d osbuilder-mount-dir.XXXX)
 	mount "${device}p1" "${mount_dir}"
 	OK "root partition mounted"
 


### PR DESCRIPTION
Immutable systems, as such Red Hat Core OS and Fedora Core OS, will not
allow mount_dir to be created in a location that's not read-write.

Let's ensure we use /tmp as base for mount_dir, as it's a safe writable
choice for any distro supported by kata.

Fixes: #437 

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>