### PR TITLE
dockerfile: QAT: Add an automated QAT kernel/rootfs builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,26 @@
 
 # osbuilder
 
-* [osbuilder](#osbuilder)
-  * [Introduction](#introduction)
-  * [Terms](#terms)
-  * [Building](#building)
-     * [Rootfs creation](#rootfs-creation)
-        * [Rootfs with systemd as init](#rootfs-with-systemd-as-init)
-        * [Rootfs with the agent as init](#rootfs-with-the-agent-as-init)
-        * [dracut based rootfs](#dracut-based-rootfs)
-     * [Image creation](#image-creation)
-        * [Image with systemd as init](#image-with-systemd-as-init)
-        * [Image with the agent as init](#image-with-the-agent-as-init)
-        * [dracut based image](#dracut-based-image)
-     * [Initrd creation](#initrd-creation)
-        * [Rootfs based initrd](#rootfs-based-initrd)
-        * [dracut based initrd](#dracut-based-initrd)
-     * [dracut options](#dracut-options)
-        * [Add kernel modules](#add-kernel-modules)
-  * [Testing](#testing)
-  * [Platform-Distro Compatibility Matrix](#platform-distro-compatibility-matrix)
+    * [Introduction](#introduction)
+    * [Terms](#terms)
+    * [Building](#building)
+        * [Rootfs creation](#rootfs-creation)
+            * [Rootfs with systemd as init](#rootfs-with-systemd-as-init)
+            * [Rootfs with the agent as init](#rootfs-with-the-agent-as-init)
+            * [dracut based rootfs](#dracut-based-rootfs)
+        * [Image creation](#image-creation)
+            * [Image with systemd as init](#image-with-systemd-as-init)
+            * [Image with the agent as init](#image-with-the-agent-as-init)
+            * [dracut based image](#dracut-based-image)
+        * [Initrd creation](#initrd-creation)
+            * [Rootfs based initrd](#rootfs-based-initrd)
+            * [dracut based initrd](#dracut-based-initrd)
+        * [dracut options](#dracut-options)
+            * [Add kernel modules](#add-kernel-modules)
+        * [Custom images](#custom-images)
+            * [QAT customized kernel and rootfs](#qat-customized-kernel-and-rootfs)
+    * [Testing](#testing)
+    * [Platform-Distro Compatibility Matrix](#platform-distro-compatibility-matrix)
 
 ## Introduction
 
@@ -187,6 +188,22 @@ is paired with the built image or initrd, using the `uname -r` format. For examp
 ```
 $ make BUILD_METHOD=dracut DRACUT_KVERSION=5.2.1-23-kata AGENT_INIT=yes initrd
 ```
+
+### Custom images
+
+The Kata Containers kernel and rootfs images are by design "minimal". If advanced or
+site specific or customized features are required, then building a customized kernel
+and/or rootfs may be required.
+
+The below are some examples which may help or be useful for generating a customized system.
+
+#### QAT customized kernel and rootfs
+
+As documented in the
+[QAT Kata use-case documentation](https://github.com/kata-containers/documentation/blob/master/use-cases/using-Intel-QAT-and-kata.md),
+QAT requires a customised kernel and rootfs to work with Kata. To ease building of the kernel
+and rootfs, a [QAT build Dockerfile](./dockerfiles/QAT) is supplied, that when run, generates
+the required kernel and rootfs binaries.
 
 ## Testing
 

--- a/dockerfiles/QAT/Dockerfile
+++ b/dockerfiles/QAT/Dockerfile
@@ -1,0 +1,52 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Kata osbuilder 'works best' on Fedora
+FROM fedora:latest
+
+# Version of the Dockerfile - update if you change this file to avoid 'stale'
+# images being pulled from the registry.
+LABEL DOCKERFILE_VERSION="1.0"
+
+ENV QAT_DRIVER_VER qat1.7.l.4.9.0-00008.tar.gz
+ENV QAT_DRIVER_URL https://01.org/sites/default/files/downloads/${QAT_DRIVER_VER}
+ENV QAT_COMPILE_OPTIONS --disable-qat-lkcf --enable-icp-sriov=guest
+
+ENV KATA_VERSION master
+ENV OUTPUT_DIR /output
+
+RUN dnf install -y \
+    bc \
+    bison \
+    curl \
+    diffutils \
+    e2fsprogs \
+    elfutils-libelf-devel \
+    findutils \
+    flex \
+    gcc \
+    gcc-c++ \
+    git \
+    kmod \
+    openssl-devel \
+    make \
+    parted \
+    patch \
+    qemu-img \
+    systemd-devel \
+    sudo \
+    xz
+
+# Pull in our local files
+COPY ./run.sh /input/
+COPY ./qat.conf /input/
+
+# Output is placed in the /output directory.
+# We could make this a VOLUME to force it to be attached to the host, but let's
+# just leave it as a container dir that can then be over-ridden from a host commandline
+# volume setup.
+# VOLUME /output
+
+# By default build everything
+CMD ["/input/run.sh"]

--- a/dockerfiles/QAT/README.md
+++ b/dockerfiles/QAT/README.md
@@ -1,0 +1,71 @@
+
+  * [Introduction](#introduction)
+  * [Building](#building)
+  * [Options](#options)
+
+## Introduction
+
+The files in this directory can be used to build a modified Kata Containers rootfs
+and kernel with modifications to support Intel QAT hardware.
+
+The generated files will need to be copied and configured into your Kata Containers
+setup.
+
+Please see the
+[Kata QAT documentation](https://github.com/kata-containers/documentation/blob/master/use-cases/using-Intel-QAT-and-kata.md)
+for more specific QAT details.
+
+## Building
+
+The image build and run are executed using Docker, from within this `QAT` folder. You
+require **all** the files in this directory to build the Docker image:
+
+```sh
+$ docker build --label kataqat --tag kataqat:latest . 
+$ mkdir ./output
+$ docker run -ti --rm --privileged -v /dev:/dev -v $(pwd)/output:/output kataqat
+```
+
+> **Note:** The use of the `--privileged` and `-v /dev:/dev` arguments to the `docker run` are
+> necessary, to enable the scripts within the container to generate a roofs file system.
+
+When complete, the generated files will be placed into the output directory. Example QAT config
+files are also placed into the `config` subdirectory for references. These files may need
+modification before use, as documented in the Kata QAT
+[use-case document](https://github.com/kata-containers/documentation/blob/master/use-cases/using-Intel-QAT-and-kata.md#copy-intel-qat-configuration-files-and-enable-virtual-functions):
+
+```sh
+# ls -lR output
+output:
+total 267316
+drwxr-xr-x 2 root root      4096 Apr  6 14:02 configs
+-rw-r--r-- 1 root root 268435456 Apr  6 14:02 kata-containers.img
+-rw-r--r-- 1 root root   5284400 Apr  6 14:02 vmlinuz-kata-linux-5.4.15-71_qat
+
+output/configs:
+total 16
+-rw-r--r-- 1 root root 4081 Apr  6 14:02 c3xxxvf_dev0.conf.vm
+-rw-r--r-- 1 root root 4081 Apr  6 14:02 c6xxvf_dev0.conf.vm
+-rw-r--r-- 1 root root 4081 Apr  6 14:02 d15xxvf_dev0.conf.vm
+-rw-r--r-- 1 root root 4081 Apr  6 14:02 dh895xccvf_dev0.conf.vm
+```
+
+## Options
+
+A number of parameters to the scripts are configured in the `Dockerfile`, and thus can be modified
+on the commandline.
+
+
+| Variable | Definition | Default value |
+| -------- | ---------- | ------------- |
+| KATA_VERSION | Kata Branch or Tag to build from | `master` |
+| OUTPUT_DIR | Directory inside container where results are stored | `/output` |
+| QAT_COMPILE_OPTIONS | `configure` options for QAT driver | `--disable-qat-lkcf --enable-icp-sriov=guest` |
+| QAT_DRIVER_URL | URL to curl QAT driver from | `https://01.org/sites/default/files/downloads/${QAT_DRIVER_VER}` |
+| QAT_DRIVER_VER | QAT driver version to use | `qat1.7.l.4.9.0-00008.tar.gz` |
+
+Variables can be set on the `docker run` commandline, for example:
+
+```sh
+$ docker run -ti --rm --privileged -e "KATA_VERSION=1.11.0" -v /dev:/dev -v ${PWD}/output:/output kataqat
+```

--- a/dockerfiles/QAT/qat.conf
+++ b/dockerfiles/QAT/qat.conf
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_PCIEAER=y
+CONFIG_UIO=y
+CONFIG_CRYPTO_HW=y
+# This is a hack. By setting this QAT device as a module, we get the kernel
+# to configure/build all the other parts required for QAT - and then later we
+# build and load the out-of-tree QAT kernel modules instead of this one.
+CONFIG_CRYPTO_DEV_QAT_C62XVF=m
+CONFIG_CRYPTO_CBC=y
+CONFIG_MODULES=y
+CONFIG_MODULE_SIG=y
+CONFIG_CRYPTO_AUTHENC=y
+CONFIG_CRYPTO_DH=y

--- a/dockerfiles/QAT/run.sh
+++ b/dockerfiles/QAT/run.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+set -u
+
+# NOTE: Some env variables are set in the Dockerfile - those that are
+# intended to be over-rideable.
+QAT_SRC=~/src/QAT
+export GOPATH=~/src/go
+export PATH=${PATH}:/usr/local/go/bin:${GOPATH}/bin
+
+packagerepo=github.com/kata-containers/packaging
+packagerepopath=${GOPATH}/src/${packagerepo}
+
+osbrepo=github.com/kata-containers/osbuilder
+osbrepopath=${GOPATH}/src/${osbrepo}
+
+testsrepo=github.com/kata-containers/tests
+testsrepopath=${GOPATH}/src/${testsrepo}
+
+runtimerepo=github.com/kata-containers/runtime
+runtimerepopath=${GOPATH}/src/${runtimerepo}
+
+agentrepo=github.com/kata-containers/agent
+agentrepopath=${GOPATH}/src/${agentrepo}
+
+grab_kata_repos()
+{
+	# Check out all the repos we will use now, so we can try and ensure they use the specified branch
+	# Only check out the branch needed, and make it shallow and thus space/bandwidth efficient
+	git clone --single-branch --branch $KATA_VERSION --depth=1 https://${packagerepo} ${packagerepopath}
+	git clone --single-branch --branch $KATA_VERSION --depth=1 https://${osbrepo} ${osbrepopath}
+	git clone --single-branch --branch $KATA_VERSION --depth=1 https://${testsrepo} ${testsrepopath}
+	git clone --single-branch --branch $KATA_VERSION --depth=1 https://${runtimerepo} ${runtimerepopath}
+	git clone --single-branch --branch $KATA_VERSION --depth=1 https://${agentrepo} ${agentrepopath}
+}
+
+configure_kernel()
+{
+	cp /input/qat.conf ${packagerepopath}/kernel/configs/fragments/common/qat.conf
+	# We need yq and go to grab kernel versions etc.
+	${testsrepopath}/.ci/install_yq.sh
+	${testsrepopath}/.ci/install_go.sh -p
+	cd ${packagerepopath}
+	./kernel/build-kernel.sh setup
+}
+
+build_kernel()
+{
+	cd ${packagerepopath}
+	LINUX_VER=$(ls -d kata-linux-*)
+	sed -i 's/EXTRAVERSION =/EXTRAVERSION = .qat.container/' $LINUX_VER/Makefile
+	./kernel/build-kernel.sh build
+}
+
+build_rootfs()
+{
+	cd ${osbrepopath}/rootfs-builder
+	# We default to using clearlinux for the QAT rootfs
+	SECCOMP=no EXTRA_PKGS='kmod' ./rootfs.sh clearlinux
+}
+
+grab_qat_drivers()
+{
+	mkdir -p $QAT_SRC
+	cd $QAT_SRC
+	curl -L $QAT_DRIVER_URL | tar zx
+}
+
+build_qat_drivers()
+{
+	cd ${packagerepopath}
+	linux_kernel_path=${packagerepopath}/${LINUX_VER}
+	KERNEL_MAJOR_VERSION=$(awk '/^VERSION =/{print $NF}' ${linux_kernel_path}/Makefile)
+	KERNEL_PATHLEVEL=$(awk '/^PATCHLEVEL =/{print $NF}' ${linux_kernel_path}/Makefile)
+	KERNEL_SUBLEVEL=$(awk '/^SUBLEVEL =/{print $NF}' ${linux_kernel_path}/Makefile)
+	KERNEL_EXTRAVERSION=$(awk '/^EXTRAVERSION =/{print $NF}' ${linux_kernel_path}/Makefile)
+	KERNEL_ROOTFS_DIR=${KERNEL_MAJOR_VERSION}.${KERNEL_PATHLEVEL}.${KERNEL_SUBLEVEL}${KERNEL_EXTRAVERSION}
+	cd $QAT_SRC
+	KERNEL_SOURCE_ROOT=${linux_kernel_path} ./configure ${QAT_COMPILE_OPTIONS}
+	make qat-driver-all quickassist-all -j$(nproc)
+}
+
+add_qat_to_rootfs()
+{
+	cd $QAT_SRC
+	ROOTFS_DIR=${osbrepopath}/rootfs-builder/rootfs-Clear
+	make INSTALL_MOD_PATH=$ROOTFS_DIR qat-driver-install -j$(nproc)
+
+	cp $QAT_SRC/build/usdm_drv.ko $ROOTFS_DIR/usr/lib/modules/${KERNEL_ROOTFS_DIR}/updates/drivers
+	depmod -a -b ${ROOTFS_DIR} ${KERNEL_ROOTFS_DIR}
+	cd ${osbrepopath}/image-builder
+	./image_builder.sh ${ROOTFS_DIR}
+}
+
+copy_outputs()
+{
+	mkdir -p ${OUTPUT_DIR} || true
+	cp ${linux_kernel_path}/arch/x86/boot/bzImage $OUTPUT_DIR/vmlinuz-${LINUX_VER}_qat
+	cp ${osbrepopath}/image-builder/kata-containers.img $OUTPUT_DIR
+	mkdir -p ${OUTPUT_DIR}/configs || true
+	cp $QAT_SRC/quickassist/utilities/adf_ctl/conf_files/*.conf.vm ${OUTPUT_DIR}/configs
+}
+
+help() {
+	cat << EOF
+Usage: $0 [-h] [options]
+   Description:
+        This script builds kernel and rootfs artifacts for Kata Containers,
+        configured and built to support QAT hardware.
+   Options:
+        -d,         Enable debug mode
+        -h,         Show this help
+EOF
+}
+
+main()
+{
+	local check_in_container=${OUTPUT_DIR:-}
+	if [ -z "${check_in_container}" ]; then
+		echo "Error: 'OUTPUT_DIR' not set" >&2
+		echo "$0 should be run using the Dockerfile supplied." >&2
+		exit -1
+	fi
+
+	local OPTIND
+	while getopts "dh" opt;do
+		case ${opt} in
+		d)
+		    set -x
+		    ;;
+		h)
+		    help
+		    exit 0;
+		    ;;
+		?)
+		    # parse failure
+		    help
+		    echo "ERROR: Failed to parse arguments"
+		    exit -1
+		    ;;
+		esac
+	done
+	shift $((OPTIND-1))
+
+	grab_kata_repos
+	configure_kernel
+	build_kernel
+	build_rootfs
+	grab_qat_drivers
+	build_qat_drivers
+	add_qat_to_rootfs
+	copy_outputs
+}
+
+main "$@"


### PR DESCRIPTION
Add a method to automatically build a modified kernel and rootfs
to support QAT.

Given we don't generally have either:
 - a fully enabled ('full fat') kernel for Kata, as it would be
   big and slow
 - kernel and rootfs variants, as that would seriously bloat our
   test matrix and CI requirements, which would likely lead to more
   strange and hard to find bugs....

maybe we can build a collection of 'helpers' to make building and
customizing a rootfs and kernel easier.

Fixes: #440

Signed-off-by: Graham Whaley <graham.whaley@intel.com>