### PR TITLE
tests: deleting stale test results when tests failed

### DIFF
--- a/tests/test_images.sh
+++ b/tests/test_images.sh
@@ -177,6 +177,7 @@ exit_handler()
 	if [ -d "${tmp_rootfs}" ]; then
 		info "rootfs:"
 		sudo -E ls -l "${tmp_rootfs}" >&2
+		sudo -E rm -rf "${tmp_rootfs}"
 	else
 		info "no rootfs created"
 		# If no rootfs are created, no need to dump other info
@@ -186,6 +187,7 @@ exit_handler()
 	if [ -d "${images_dir}" ]; then
 		info "images:"
 		sudo -E ls -l "${images_dir}" >&2
+		sudo -E rm -rf "${images_dir}"
 	else
 		info "no images created"
 		# If no images are created, no need to dump other info


### PR DESCRIPTION
**Which feature do you think can be improved?**
When debugging ARM CI failure in https://github.com/kata-containers/ci/issues/268, I found tons of stale test results under `/tmp`, which were traced back to here [osbuilder/tests/test_images.sh](https://github.com/kata-containers/osbuilder/blob/master/tests/test_images.sh#L15)
```
root@arm-testing-2:~# du -k --max-depth=1 /tmp | grep "osbuilder-test"
36      /tmp/osbuilder-test.6On2ZYj
1209852 /tmp/osbuilder-test.mdWy5TB
1174800 /tmp/osbuilder-test.yH3xtJI
1174780 /tmp/osbuilder-test.HNgoRc1
1209860 /tmp/osbuilder-test.aBtTRjD
1174788 /tmp/osbuilder-test.jOmHsag
1209868 /tmp/osbuilder-test.GdEFsPu
1209860 /tmp/osbuilder-test.g7IBuy1
1051776 /tmp/osbuilder-test.TS7agUD
673268  /tmp/osbuilder-test.8OFe9vA
1209868 /tmp/osbuilder-test.7KP8xJ1
1209864 /tmp/osbuilder-test.9BWbdlN
1466152 /tmp/osbuilder-test.wmxRIRT
806748  /tmp/osbuilder-test.YvJfdKD
1210060 /tmp/osbuilder-test.3EAmdoB
1051688 /tmp/osbuilder-test.LXP7bZG
1174804 /tmp/osbuilder-test.nGoOzCI
806752  /tmp/osbuilder-test.SOQTou7
806776  /tmp/osbuilder-test.eB1ekVe
1209868 /tmp/osbuilder-test.fHiAJmX
771704  /tmp/osbuilder-test.U79Qjvl
771700  /tmp/osbuilder-test.ksJG5Bv
1174788 /tmp/osbuilder-test.ZuhvaB2
1174920 /tmp/osbuilder-test.tEqM3Vb
8       /tmp/osbuilder-test.xAvXMc3
root@arm-testing-2:~# du -k --max-depth=1 /tmp | grep "osbuilder-test" | awk '{Total+=$1} END {print Total/1024/1024" GB"}'
23.7795 GB
```

**How can it be improved?**

I found that right now we only dumped test results for debugging, when tests failed.
we should also delete them for avoiding leaving stale test results under `/tmp`.
