### PR TITLE
rootfs-builder: add DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/rootfs-builder/debian/Dockerfile-aarch64.in
+++ b/rootfs-builder/debian/Dockerfile-aarch64.in
@@ -6,6 +6,9 @@
 # NOTE: OS_VERSION is set according to config.sh
 from docker.io/debian:@OS_VERSION@
 
+#environment variable declaration, etc
+@SET_UP@
+
 # RUN commands
 RUN apt-get update && apt-get install -y \
     autoconf \

--- a/rootfs-builder/debian/Dockerfile.in
+++ b/rootfs-builder/debian/Dockerfile.in
@@ -6,6 +6,9 @@
 # NOTE: OS_VERSION is set according to config.sh
 from docker.io/debian:@OS_VERSION@
 
+#environment variable declaration, etc
+@SET_UP@
+
 # RUN commands
 RUN apt-get update && apt-get --no-install-recommends install -y \
     apt-utils \

--- a/rootfs-builder/ubuntu/Dockerfile-aarch64.in
+++ b/rootfs-builder/ubuntu/Dockerfile-aarch64.in
@@ -7,6 +7,9 @@
 #@OS_VERSION@: Docker image version to build this dockerfile
 from docker.io/ubuntu:@OS_VERSION@
 
+#environment variable declaration, etc
+@SET_UP@
+
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)
 

--- a/rootfs-builder/ubuntu/Dockerfile.in
+++ b/rootfs-builder/ubuntu/Dockerfile.in
@@ -7,6 +7,9 @@
 #@OS_VERSION@: Docker image version to build this dockerfile
 from docker.io/ubuntu:@OS_VERSION@
 
+#environment variable declaration, etc
+@SET_UP@
+
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -274,6 +274,14 @@ generate_dockerfile()
 	curlOptions=("-OL")
 	[ -n "${http_proxy:-}" ] && curlOptions+=("-x ${http_proxy:-}")
 
+	# This only applies to ubuntu/debian
+	# Use this mode when you need zero interaction while
+	# installing or upgrading the system via apt.
+	# It accepts the default answer for all questions.
+	readonly set_up="
+ENV DEBIAN_FRONTEND=noninteractive
+"
+
 	readonly install_go="
 RUN cd /tmp ; curl ${curlOptions[@]} https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${goarch}.tar.gz
 RUN tar -C /usr/ -xzf /tmp/go${GO_VERSION}.linux-${goarch}.tar.gz
@@ -357,6 +365,7 @@ RUN ln -sf /usr/bin/g++ /bin/musl-g++
 	# also long double representation problem when building musl-libc
 	if [ "${architecture}" == "ppc64le" ] || [ "${architecture}" == "s390x" ]; then
 		sed \
+			-e "s|@SET_UP@|${set_up//$'\n'/\\n}|g" \
 			-e "s|@GO_VERSION@|${GO_VERSION}|g" \
 			-e "s|@OS_VERSION@|${OS_VERSION:-}|g" \
 			-e "s|@INSTALL_CMAKE@||g" \
@@ -367,6 +376,7 @@ RUN ln -sf /usr/bin/g++ /bin/musl-g++
 			${dockerfile_template} > Dockerfile
 	else
 		sed \
+			-e "s|@SET_UP@|${set_up//$'\n'/\\n}|g" \
 			-e "s|@GO_VERSION@|${GO_VERSION}|g" \
 			-e "s|@OS_VERSION@|${OS_VERSION:-}|g" \
 			-e "s|@INSTALL_CMAKE@|${install_cmake//$'\n'/\\n}|g" \


### PR DESCRIPTION
# Description of problem
Now, ARM CI failed on the following errors:
https://github.com/kata-containers/ci/issues/276
```
05:09:13 Setting up tzdata (2019c-3ubuntu1) ...
05:09:13 debconf: unable to initialize frontend: Dialog
05:09:13 debconf: (TERM is not set, so the dialog frontend is not usable.)
05:09:13 debconf: falling back to frontend: Readline
05:09:13 Configuring tzdata
05:09:13 ------------------
05:09:13 
05:09:13 Please select the geographic area in which you live. Subsequent configuration
05:09:13 questions will narrow this down by presenting a list of cities, representing
05:09:13 the time zones in which they are located.
05:09:13 
05:09:13   1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
05:09:13   2. America     5. Arctic     8. Europe    11. SystemV
05:09:13   3. Antarctica  6. Asia       9. Indian    12. US
05:09:13 Geographic area: Build timed out (after 15 minutes). Marking the build as aborted.
05:24:13 Build was aborted
```
The interface of debconf is configured to `Readline`, and this frontend will prompt a series of questions, printed out at the console using plain text for users to choose.

# Expected result

In container, we need to configure `DEBIAN_FRONTEND=noninteractive`, which will let user have zero interaction while installing or upgrading the system via apt. It accepts the default answer for all questions.
