### PR TITLE
[backport-1.10] image-builder: disable reflink

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -320,7 +320,12 @@ format_loop() {
 			;;
 
 		"${xfs_format}")
-			mkfs.xfs -q -f -b size="${block_size}" "${device}p1"
+			# DAX and reflink cannot be used together!
+			# Explicitly disable reflink, if it fails then reflink
+			# is not supported and '-m reflink=0' is not needed.
+			if mkfs.xfs -m reflink=0 -q -f -b size="${block_size}" "${device}p1" 2>&1 | grep -q "unknown option"; then
+				mkfs.xfs -q -f -b size="${block_size}" "${device}p1"
+			fi
 			;;
 
 		*)


### PR DESCRIPTION
Disable reflink when using DAX. Reflink is a xfs feature that cannot be
used together with DAX.

fixes #455

Signed-off-by: Julio Montes <julio.montes@intel.com>