### PR TITLE
rootfs: Upgrade fedora images for Dockerfile

### DIFF
--- a/rootfs-builder/clearlinux/Dockerfile.in
+++ b/rootfs-builder/clearlinux/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From docker.io/fedora:30
+From docker.io/fedora:32
 
 @SET_PROXY@
 

--- a/rootfs-builder/fedora/config.sh
+++ b/rootfs-builder/fedora/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Fedora"
 
-OS_VERSION=${OS_VERSION:-30}
+OS_VERSION=${OS_VERSION:-32}
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"
 

--- a/rootfs-builder/fedora/config_aarch64.sh
+++ b/rootfs-builder/fedora/config_aarch64.sh
@@ -5,6 +5,6 @@
 
 # image busybox will fail on fedora 30 rootfs image
 # see https://github.com/kata-containers/osbuilder/issues/334 for detailed info
-OS_VERSION="29"
+OS_VERSION="32"
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"


### PR DESCRIPTION
This PR upgrades the fedora image that is used in the Dockerfile to build
the rootfs. The main purpose is to avoid random failures in getting the
mirrors for fedora 30.

Fixes #462

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>