### PR TITLE
rootfs-builder: Don't modify /sbin/init on the build host

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -667,7 +667,6 @@ main()
 {
 	parse_arguments $*
 	check_env_variables
-	init="${ROOTFS_DIR}/sbin/init"
 
 	if [ -n "$distro" ]; then
 		build_rootfs_distro
@@ -680,6 +679,7 @@ main()
 		prepare_overlay
 	fi
 
+	init="${ROOTFS_DIR}/sbin/init"
 	setup_rootfs
 }
 


### PR DESCRIPTION
Don't modify /sbin/init on the build host when using command `AGENT_INIT="yes" ./rootfs.sh centos` to build rootfs.

Fixes: #472

Signed-off-by: liangxianlong <liang.xianlong@zte.com.cn>