### PR TITLE
rootf-builder: fix unbootable dracut-based initramfs on Fedora

### DIFF
--- a/image-builder/image_builder.sh
+++ b/image-builder/image_builder.sh
@@ -186,7 +186,7 @@ check_rootfs() {
 	OK "init is installed"
 
 
-	systemd_path="/lib/systemd/systemd"
+	systemd_path="/usr/lib/systemd/systemd"
 	systemd="${rootfs}${systemd_path}"
 
 	# check agent or systemd

--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -454,8 +454,7 @@ prepare_overlay()
 	# we were passed a pre-populated rootfs directory
 	if [ ! -e ./sbin/init ]; then
 		ln -sf  ./usr/lib/systemd/systemd ./init
-		ln -sf  ../../init ./lib/systemd/systemd
-		ln -sf  ../init ./sbin/init
+		ln -sf  /init ./sbin/init
 	fi
 
 	# Kata systemd unit file


### PR DESCRIPTION
Fix a problem caused by the fact that on Fedora - but also Debian,
Ubuntu and most likely others, /lib and /sbin aren't directories but
symlinks to /usr/lib and /usr/sbin, respectively.  So when the commands

  ln -sf  ../../init ./lib/systemd/systemd
  ln -sf  ../init ./sbin/init

with relative targets meant to mean /init are executed on such distros,
the link name ./lib/systemd/systemd actually becomes
./usr/lib/systemd/systemd, ./sbin/init becomes ./usr/sbin/init and their
target turns out to be /usr/init which means that they dangle.

What's more, that the symlink created by the former 'ln' command
actually ends up at /usr/lib/systemd/systemd means that this dangling
link overwrites the actual systemd binary later on when dracut applies
this overlay to its tree.  This makes the initramfs unbootable for the
case where systemd is used as init.

But even if kata-agent is used as init the resulting initramfs still
doesn't boot.  This is apparently because while kata-agent is /sbin/init
in the overlay, this becomes /usr/sbin/init when dracut is applying the
overlay.  But there already is a /usr/sbin/init in the dracut tree which
is symlink to ../lib/systemd/systemd - in other words, to
/usr/lib/systemd/systemd.  That however is the same dangling symlink
discussed in previous paragraph.  The net result is that 'cp' refuses to
copy kata-agent binary to the dangling symlink(*) and kata-agent never
makes it to the initramfs.

This fix changes the target of the latter of the above 'ln' commands to
absolute.  This should remove the ambiguity and accommodate both distros
where /lib is a proper directory and those where /lib->/usr/lib.  It
also drops the former command altogether.  The link caused buggy
behaviour on distros with /lib->/usr/lib as described above, and
checking openSUSE - a distro with /lib and /sbin as proper directories
as opposed to symlinks - the path /lib/systemd/systemd seems to exist
neither on its initramfs nor the real root filesystem so I assume
openSUSE should be fine with this link dropped.

(*) The error message is along the lines of
cp: not writing through dangling symlink '/var/tmp/dracut.KVCEjs/initramfs///sbin/init'

Fixes #399

Signed-off-by: Pavel Mores <pmores@redhat.com>