### PR TITLE
rootfs-builder: update centos arch key path

### DIFF
--- a/rootfs-builder/centos/config_aarch64.sh
+++ b/rootfs-builder/centos/config_aarch64.sh
@@ -13,6 +13,6 @@ CENTOS_EXTRAS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/extras/${ARCH}
 
 CENTOS_PLUS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/centosplus/${ARCH}/"
 
-GPG_KEY_ARCH_URL="http://mirror.centos.org/altarch/7/os/aarch64/RPM-GPG-KEY-CentOS-7-aarch64"
+GPG_KEY_ARCH_URL="https://github.com/CentOS/sig-core-AltArch/raw/master/centos-release-repo/centos-release-7/aarch64/RPM-GPG-KEY-CentOS-7-aarch64"
 
 GPG_KEY_ARCH_FILE="RPM-GPG-KEY-CentOS-7-aarch64"

--- a/rootfs-builder/centos/config_ppc64le.sh
+++ b/rootfs-builder/centos/config_ppc64le.sh
@@ -13,6 +13,6 @@ CENTOS_EXTRAS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/extras/${ARCH}
 
 CENTOS_PLUS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/centosplus/${ARCH}/"
 
-GPG_KEY_ARCH_URL="http://mirror.centos.org/altarch/7/os/ppc64le/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le"
+GPG_KEY_ARCH_URL="https://github.com/CentOS/sig-core-AltArch/raw/master/centos-release-repo/centos-release-7/ppc/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le"
 
 GPG_KEY_ARCH_FILE="RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le"


### PR DESCRIPTION
The key path of centos has removed from mirrors

Fixes #482

Signed-off-by: choury <chouryzhou@tencent.com>