### PR TITLE
rootfs: Skip installing cargo and rust for docker build

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -370,7 +370,7 @@ build_rootfs_distro()
 		image_name="${distro}-rootfs-osbuilder"
 
 		# setup to install go or rust here
-		generate_dockerfile "${distro_config_dir}"
+		generate_dockerfile "${distro_config_dir}" "${RUST_AGENT}"
 		"$container_engine" build  \
 			--build-arg http_proxy="${http_proxy}" \
 			--build-arg https_proxy="${https_proxy}" \


### PR DESCRIPTION
For the docker build of the rootfs based on golang agent,
we still end up installing these packages. Skip these.

Fixes #507

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>