### PR TITLE
backport: rootfs: Skip installing cargo and rust for docker build

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -370,7 +370,7 @@ build_rootfs_distro()
 		image_name="${distro}-rootfs-osbuilder"
 
 		# setup to install go or rust here
-		generate_dockerfile "${distro_config_dir}"
+		generate_dockerfile "${distro_config_dir}" "${RUST_AGENT}"
 		"$container_engine" build  \
 			--build-arg http_proxy="${http_proxy}" \
 			--build-arg https_proxy="${https_proxy}" \

--- a/rootfs-builder/template/rootfs_lib_template.sh
+++ b/rootfs-builder/template/rootfs_lib_template.sh
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 # - Arguments
 # rootfs_dir=$1
 #

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -247,6 +247,8 @@ generate_dockerfile()
 	dir="$1"
 	[ -d "${dir}" ] || die "${dir}: not a directory"
 
+	RUST_AGENT=${2:-"no"}
+
 	local architecture=$(uname -m)
 	local rustarch=${architecture}
 	local muslarch=${architecture}
@@ -297,10 +299,12 @@ RUN pushd /root; \
 "
 	# install musl for compiling rust-agent
 	install_musl=
-	if [ "${muslarch}" == "aarch64" ]; then
-		local musl_tar="${muslarch}-linux-musl-native.tgz"
-		local musl_dir="${muslarch}-linux-musl-native"
-		install_musl="
+	install_rust=
+	if [ "${RUST_AGENT}" == "yes" ]; then
+		if [ "${muslarch}" == "aarch64" ]; then
+			local musl_tar="${muslarch}-linux-musl-native.tgz"
+			local musl_dir="${muslarch}-linux-musl-native"
+			install_musl="
 RUN cd /tmp; \
 	curl -sLO https://musl.cc/${musl_tar}; tar -zxf ${musl_tar}; \
 	 mkdir -p /usr/local/musl/; \
@@ -308,10 +312,10 @@ RUN cd /tmp; \
 ENV PATH=\$PATH:/usr/local/musl/bin
 RUN ln -sf /usr/local/musl/bin/g++ /usr/bin/g++
 "
-	else
-		local musl_tar="musl-${MUSL_VERSION}.tar.gz"
-		local musl_dir="musl-${MUSL_VERSION}"
-		install_musl="
+		else
+			local musl_tar="musl-${MUSL_VERSION}.tar.gz"
+			local musl_dir="musl-${MUSL_VERSION}"
+			install_musl="
 RUN pushd /root; \
     curl -sLO https://www.musl-libc.org/releases/${musl_tar}; tar -zxf ${musl_tar}; \
 	cd ${musl_dir}; \
@@ -323,9 +327,9 @@ RUN pushd /root; \
 	popd
 ENV PATH=\$PATH:/usr/local/musl/bin
 "
-	fi
+		fi
 
-	readonly install_rust="
+		install_rust="
 RUN curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSLf --output /tmp/rust-init; \
     chmod a+x /tmp/rust-init; \
 	export http_proxy=${http_proxy:-}; \
@@ -340,8 +344,8 @@ RUN . /root/.cargo/env; \
 	rustup target install ${rustarch}-unknown-linux-musl
 RUN ln -sf /usr/bin/g++ /bin/musl-g++
 "
-	# rust agent still need go to build
-	# because grpc-sys need go to build
+	fi
+
 	pushd ${dir}
 	dockerfile_template="Dockerfile.in"
 	dockerfile_arch_template="Dockerfile-${architecture}.in"


### PR DESCRIPTION
For the docker build of the rootfs based on golang agent,
we still end up installing these packages. Skip these.

Fixes #507

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
(cherry picked from commit b937cf70342a1dbf14e7e145f5083c9c10a63584)