### PR TITLE
backport: rootfs: Skip installing cargo and rust for docker build

### DIFF
--- a/rootfs-builder/rootfs.sh
+++ b/rootfs-builder/rootfs.sh
@@ -370,7 +370,7 @@ build_rootfs_distro()
 		image_name="${distro}-rootfs-osbuilder"
 
 		# setup to install go or rust here
-		generate_dockerfile "${distro_config_dir}"
+		generate_dockerfile "${distro_config_dir}" "${RUST_AGENT}"
 		"$container_engine" build  \
 			--build-arg http_proxy="${http_proxy}" \
 			--build-arg https_proxy="${https_proxy}" \

--- a/rootfs-builder/template/rootfs_lib_template.sh
+++ b/rootfs-builder/template/rootfs_lib_template.sh
@@ -1,3 +1,8 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 # - Arguments
 # rootfs_dir=$1
 #


### PR DESCRIPTION
For the docker build of the rootfs based on golang agent,
we still end up installing these packages. Skip these.

Fixes #507

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
(cherry picked from commit b937cf70342a1dbf14e7e145f5083c9c10a63584)