### PR TITLE
Makefile: update copyright dates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2017-2021 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
The real reason for this commit is to trigger the CI to check if a change in the
runtime versions.yaml file fixes an issue we saw there.

Fixes: #521

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>